### PR TITLE
support for handlebars templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,24 @@ Templates (`build.html` and `interface.html`) get compiled through Handlebars. I
 <div>\{{foo}}</div>
 <template name="bar">\{{#if foo}} \{{foo}} \{{/if}}</template>
 ```
+
+## Using Handlebars in your client
+
+You can also use handlebars templates in your client-side code and let the system compile them.
+
+1. Add `handlebars` in your widget.json dependencies
+2. Add a reference to `js/interface.templates.js` or `js/build.templates.js` in your build or interface assets
+3. Create your templates anywhere in the folders of your component. Please note that the folder structure will be used as namespace for your templates. They will be available under the `Fliplet.Widget.Templates` object.
+
+e.g. given the following template:
+
+```
+js/foo/bar.interface.hbs
+```
+
+The handlebars-compiled template will be available as:
+
+```
+var tpl = Fliplet.Widget.Templates['foo.bar'];
+var html = tpl({ sample: 123 })
+```

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ e.g. given the following template:
 js/foo/bar.interface.hbs
 ```
 
+Files that ends with `.interface.hbs` will be compiled to the interface template file. Same applies for `.build.hbs` and the build template.
+
 The handlebars-compiled template will be available as:
 
 ```

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ You can also use handlebars templates in your client-side code and let the syste
 2. Add a reference to `js/interface.templates.js` or `js/build.templates.js` in your build or interface assets
 3. Create your templates anywhere in the folders of your component. Please note that the folder structure will be used as namespace for your templates. They will be available under the `Fliplet.Widget.Templates` object.
 
+Files that ends with `.interface.hbs` will be compiled to the interface template file. Same applies for `.build.hbs` and the build template.
+
 e.g. given the following template:
 
 ```
 js/foo/bar.interface.hbs
 ```
-
-Files that ends with `.interface.hbs` will be compiled to the interface template file. Same applies for `.build.hbs` and the build template.
 
 The handlebars-compiled template will be available as:
 

--- a/fliplet-run-widget.js
+++ b/fliplet-run-widget.js
@@ -3,7 +3,13 @@ const fs = require('fs');
 const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
-const exec = require('child_process').exec;
+const grunt = require('grunt');
+const child_process = require('child_process');
+const exec = child_process.exec;
+
+const gruntFile = require('./lib/gruntfile');
+grunt.task.init = function() {};
+gruntFile(grunt);
 
 const folderPath = process.cwd();
 const packagePath = path.join(folderPath, 'widget.json');
@@ -136,6 +142,8 @@ app.listen(3000, function () {
   if (process.argv.length > 2) {
     return;
   }
+
+  grunt.tasks(['default']);
 
   setTimeout(function () {
     try {

--- a/lib/gruntfile.js
+++ b/lib/gruntfile.js
@@ -1,0 +1,44 @@
+module.exports = function(grunt) {
+
+  // Load the plugins
+  require('grunt-contrib-watch')(grunt);
+  require('grunt-contrib-handlebars')(grunt);
+
+  // Project configuration
+  grunt.initConfig({
+    handlebars: {
+      dist: {
+        options: {
+          namespace: 'Fliplet.Widget.Templates',
+          processName: function(filePath) {
+            const fileName = filePath
+              .replace(/^js\//, '')
+              .replace(/\.(interface|build)\.hbs$/, '')
+              .replace(/\//, '.');
+
+            return fileName;
+          }
+        },
+        files: {
+          'js/interface.templates.js': '**/*.interface.hbs',
+          'js/build.templates.js': '**/*.build.hbs'
+        }
+      }
+    },
+    watch: {
+      handlebars: {
+        files: ['**/*.hbs'],
+        tasks: ['handlebars'],
+        options: {
+          livereload: true,
+          spawn: false
+        }
+      }
+    }
+  });
+
+  grunt.registerTask('build', ['handlebars']);
+
+  // Default task for development
+  grunt.registerTask('default', ['build', 'watch']);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "1.9.6",
+  "version": "2.0.0",
   "description": "",
   "main": "fliplet.js",
   "scripts": {
@@ -19,6 +19,9 @@
     "commander": "^2.9.0",
     "configstore": "^2.1.0",
     "express": "^4.14.0",
+    "grunt": "^1.0.1",
+    "grunt-contrib-handlebars": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "handlebars": "^4.0.5",
     "lodash": "^4.16.4",
     "ncp": "^2.0.0",


### PR DESCRIPTION
## Using Handlebars in your client-side JS files

You can now use handlebars templates in your client-side code and let the system compile them.

1. Add `handlebars` in your widget.json dependencies
2. Add a reference to `js/interface.templates.js` or `js/build.templates.js` in your build or interface assets
3. Create your templates anywhere in the folders of your component. Please note that the folder structure will be used as namespace for your templates. They will be available under the `Fliplet.Widget.Templates` object.

Files that ends with `.interface.hbs` will be compiled to the interface template file. Same applies for `.build.hbs` and the build template.

e.g. given the following template:

```
js/foo/bar.interface.hbs
```

The handlebars-compiled template will be available as:

```
var tpl = Fliplet.Widget.Templates['foo.bar'];
var html = tpl({ sample: 123 })
```

---

Notes:
- templates are recompiled automatically if the CLI is running
- make sure you recompile the templates at least once (by running the CLI and then stopping it) if you're making changes that you need to commit.
- commit your templates.js files, because the API won't compile handlebars templates when you upload a widget