### PR TITLE
clone widgets

### DIFF
--- a/docs/Cloning-widgets.md
+++ b/docs/Cloning-widgets.md
@@ -1,0 +1,47 @@
+# Working with your components
+
+Once you have published a component on Fliplet, its source can be retrieved at any time from any machine as long as you're logged in on the CLI with an account that has got access to it.
+
+Simply use the `clone` command to download a copy of the source code, given a component package name:
+
+```shell
+$ fliplet clone com.fliplet.primary-button
+
+Cloning widget Primary Button (com.fliplet.primary-button).
+
+Please type the path where this widget should be saved to. Press return to use "widget-primary-button".
+Done! Widget cloned to "widget-primary-button".
+```
+
+---
+
+You can also list all components you have got access to, by using the `list` command as follows:
+
+```shell
+$ fliplet list
+
+Here's the widgets you have access to and can be downloaded:
+
+• Inline Link
+  - Package name: com.fliplet.inline-link
+  - Version: 1.0.0
+
+• Primary Button
+  - Package name: com.fliplet.primary-button
+  - Version: 1.0.0
+
+• Push notifications
+  - Package name: com.fliplet.push-notifications
+  - Version: 1.0.0
+
+To download a widget, type: fliplet clone <packageName>
+```
+
+---
+
+To publish a component on Fliplet, please refer to the [publishing](../Publishing.md) documentation.
+
+---
+
+[Back](README.md)
+{: .buttons}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,11 +14,12 @@ To get a brief introduction to the technologies we use and the stack of the plat
   - [Building menus](Building-menus.md)
 3. [Publishing](Publishing.md)
 4. [Testing](Testing-components.md)
-5. [API Documentation](API-Documentation.md)
-6. UI Guidelines
+5. [Working with your components](Cloning-widgets.md)
+6. [API Documentation](API-Documentation.md)
+7. UI Guidelines
   - [Guidelines for component interfaces](UI-guidelines-interface.md)
   - [Guidelines for component output](UI-guidelines-build.md)
-7. Going forward
+8. Going forward
   - [Using providers](components/Using-Providers.md)
   - [Dependencies and assets](Dependencies-and-assets.md)
   - [Sending events between components](Event-emitter.md)

--- a/fliplet-clone.js
+++ b/fliplet-clone.js
@@ -1,0 +1,81 @@
+const request = require('request');
+const prompt = require('prompt');
+const unzipper = require('unzipper');
+const Spinner = require('cli-spinner').Spinner;
+
+const config = require('./lib/config');
+
+const user = config.data.user || {};
+const email = user.email
+const auth_token = user.auth_token;
+const organization = config.organization;
+const widgetId = process.argv[2];
+
+if (!widgetId) {
+  log('Package name is required');
+  process.exit();
+}
+
+if (!email || !auth_token) {
+  console.error('You must be logged in to perform this action');
+  process.exit();
+}
+
+request(`${config.api_url}v1/widgets/${widgetId}`, function (error, response, body) {
+  if (error) {
+    console.error(error);
+    return process.exit();
+  }
+
+  body = JSON.parse(body);
+
+  if (body.error) {
+    console.error(body.error);
+    return process.exit();
+  }
+
+  const widget = body.widget;
+
+  if (!widget.sourceUrl) {
+    console.error('Source code for this widget is not available');
+    return process.exit();
+  }
+
+  const widgetName = widget.name.toLowerCase().trim().replace(/ /g, '-').replace(/^com-/, '');
+  const prefix = widget.isTheme ? 'theme' : (widget.tags.indexOf('type:menu') !== -1 ? 'menu' : 'widget');
+  let folderName = `${prefix}-${widgetName}`;
+
+  console.log(`Cloning widget ${widget.name} (${widget.package}).`);
+  console.log(``);
+  console.log(`Please type the path where this widget should be saved to. Press return to use "${folderName}".`);
+
+  prompt.start();
+  prompt.get([
+    {
+      name: 'folder',
+      required: true,
+      default: folderName
+    }
+  ], function (err, result) {
+    if (!result) {
+      return;
+    }
+
+    folderName = result.folder;
+
+    var spinner = new Spinner('Downloading source code %s');
+    spinner.setSpinnerString(19);
+    spinner.start();
+
+    request(widget.sourceUrl)
+      .pipe(unzipper.Extract({ path: folderName }))
+      .promise()
+      .then(function () {
+        spinner.stop(true);
+        console.log(`Done! Widget cloned to "${folderName}".`);
+      }).catch(function (err) {
+        spinner.stop(true);
+        console.error(err);
+      })
+  });
+});

--- a/fliplet-list.js
+++ b/fliplet-list.js
@@ -1,0 +1,43 @@
+const request = require('request');
+
+const config = require('./lib/config');
+
+const user = config.data.user || {};
+const email = user.email
+const auth_token = user.auth_token;
+const organization = config.organization;
+
+if (!email || !auth_token) {
+  console.error('You must be logged in to perform this action');
+  process.exit();
+}
+
+request(`${config.api_url}v1/widgets`, function (error, response, body) {
+  if (error) {
+    console.error(error);
+    return process.exit();
+  }
+
+  if (body.error) {
+    console.error(body.error);
+    return process.exit();
+  }
+
+  body = JSON.parse(body);
+
+  console.log(`Here's the widgets you have access to and can be downloaded:`);
+  console.log();
+
+  body.widgets.forEach(function (widget) {
+    if (widget.sourceUrl) {
+      console.log(`• ${widget.name}`);
+      console.log(`  - Package name: ${widget.package}`);
+      console.log(`  - Version: ${widget.version}`);
+      console.log(``);
+    }
+  });
+
+  console.log('');
+  console.log('To download a widget, type: fliplet clone <packageName>');
+  console.log('');
+});

--- a/fliplet.js
+++ b/fliplet.js
@@ -12,6 +12,8 @@ program
   .command('run', 'Run the current widget or theme for development.')
   .command('publish', 'Publish the current widget or theme on fliplet studio.')
   .command('test', 'Run tests on the current widget or theme on fliplet studio.')
+  .command('list', 'List widgets you can download for editing.')
+  .command('clone [package]', 'Downloads a widget locally, given its ID or package name')
   .command('list-assets', 'Gets the list of the available assets in the system.')
   .command('list-organizations', 'Gets the list of the available organizations in the system.')
   .command('organization [id]', 'Set current working organization. Use without id to reset.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Command line utility for creating and running components, themes and menus to be used on the Fliplet platform.",
   "main": "fliplet.js",
   "scripts": {
@@ -36,6 +36,7 @@
     "replace": "^0.3.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.0",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "unzipper": "^0.8.8"
   }
 }


### PR DESCRIPTION
Once you have published a component on Fliplet, its source can now be retrieved at any time from any machine as long as you're logged in on the CLI with an account that has got access to it.

Simply use the `clone` command to download a copy of the source code, given a component package name:

```
$ fliplet clone com.fliplet.primary-button

Cloning widget Primary Button (com.fliplet.primary-button).

Please type the path where this widget should be saved to. Press return to use "widget-primary-button".
Done! Widget cloned to "widget-primary-button".
```

---

You can also list all components you have got access to, by using the `list` command as follows:

```
$ fliplet list

Here's the widgets you have access to and can be downloaded:

• Inline Link
  - Package name: com.fliplet.inline-link
  - Version: 1.0.0

• Primary Button
  - Package name: com.fliplet.primary-button
  - Version: 1.0.0

• Push notifications
  - Package name: com.fliplet.push-notifications
  - Version: 1.0.0

To download a widget, type: fliplet clone <packageName>
```
