### PR TITLE
support for app-storage

### DIFF
--- a/fliplet-run.js
+++ b/fliplet-run.js
@@ -33,6 +33,11 @@ var package;
 var widgetInstanceData;
 var runningPort;
 
+const dummyApp = {
+  id: casual.integer(1, 99999),
+  name: casual.title
+};
+
 const widgetUUID = uuid();
 
 const scriptTagsRegExp = /<script.+src=".+".+>/;
@@ -181,6 +186,7 @@ app.get('/build', function (req, res) {
     template.compile({
       topMenu,
       page,
+      app: dummyApp,
       widgets: [{
         id: Date.now(),
         name: package.name,
@@ -233,6 +239,7 @@ app.get('/interface', function (req, res) {
     template.compile({
       development: true,
       interface: true,
+      app: dummyApp,
       provider: !!req.query.providerId,
       providerId: req.query.providerId,
       providerMode: req.query.providerMode,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Command line utility for creating and running components, themes and menus to be used on the Fliplet platform.",
   "main": "fliplet.js",
   "scripts": {


### PR DESCRIPTION
`appId` is now being generated when you start the dev server with `fliplet run`, so `Fliplet.App.Storage` now works because it's able to read from the same ID.