### PR TITLE
Adds Fliplet OAuth2 documentation

### DIFF
--- a/docs/AJAX-cross-domain.md
+++ b/docs/AJAX-cross-domain.md
@@ -34,7 +34,7 @@ Service providers sometimes allow you to define domains that can use their APIs.
 
 ## 2. Configure the service with an `Access-Control-Allow-Origin` header
 
-Similar to the first method, the responses from the requested resource should contain an `Access-Control-Allow-Origin` header. The value of which could be a list of domains such as `http://domain1.example, http://domain2.example` or as mentioned above, we recommend setting it as `*` if possible.
+Similar to the first method, the responses from the requested resource should contain an `Access-Control-Allow-Origin` header. The value of which could be a list of domains such as `http://domain1.example, http://domain2.example`. For reasons mentioned above, we recommend setting it as `*` if possible.
 
 ## 3. Use a proxy service
 

--- a/docs/AJAX-cross-domain.md
+++ b/docs/AJAX-cross-domain.md
@@ -1,0 +1,43 @@
+# AJAX cross domain and cross-origin requests
+
+A common problem for developers is a browser to refuse access to a remote resource. Usually, this happens when you execute **AJAX cross domain request** using jQuery Ajax interface, Fetch API, or plain XMLHttpRequest. As result is that the AJAX request is not performed and data are not retrieved.
+
+This can usually be spotted with an error message from the browser such as below:
+
+```
+XMLHttpRequest cannot load. No 'Access-Control-Allow-Origin' header is present on the requested resource.
+```
+
+This is because Fliplet apps make AJAX requests from the following domains:
+
+**Fliplet Studio**
+
+  * `https://production.studio.fliplet.com/*`
+  * `https://api.fliplet.com/*`
+
+**Web apps**
+
+  * `https://apps.fliplet.com/*` (For EU customers)
+  * `https://us-apps.fliplet.com/*` (For US customers)
+
+**Native apps**
+
+  * `file://*`
+
+If the requested resource or service is not set up to support cross-domain requests, AJAX requests will likely fail.
+
+If you encounter this issue, there are usually 3 ways to resolve it, depending on how much access or control you have over the requested resource.
+
+## 1. Configure the requested resource to allow Fliplet's app domains
+
+Service providers sometimes allow you to define domains that can use their APIs. You can find at the top of the page a list of domains that are used. However, because native apps use the `file://*` protocol and does not contain any specific domain, we recommend setting the service provider to allow all domains if possible. This is often done by setting the allowed domains using the character `*`.
+
+## 2. Configure the service with an `Access-Control-Allow-Origin` header
+
+Similar to the first method, the responses from the requested resource should contain an `Access-Control-Allow-Origin` header. The value of which could be a list of domains such as `http://domain1.example, http://domain2.example` or as mentioned above, we recommend setting it as `*` if possible.
+
+## 3. Use a proxy service
+
+A proxy service acts as an intermediary for requests from the requester to the requested resource. The request to the requested resource is therefore made via a server and not via a web page, which bypasses the AJAX cross domain restriction. You can either use an existing proxy service or create your own.
+
+{: .buttons}

--- a/docs/API-Documentation.md
+++ b/docs/API-Documentation.md
@@ -20,11 +20,12 @@ These JS APIs falls into the most common category and almost all apps, component
 - [Fliplet Database](API/fliplet-database.md) (`fliplet-database`) (Beta)
 - [Fliplet Media](API/fliplet-media.md) (`fliplet-media`)
 - [Fliplet Notifications](API/fliplet-notifications.md) (`fliplet-notifications`)
+- [Fliplet OAuth2](API/fliplet-oauth2.md) (`fliplet-oauth2`) (Beta)
 - [Fliplet Session](API/fliplet-session.md) (`fliplet-session`)
 - [Fliplet Studio UI](UI-guidelines-interface.md) (`fliplet-studio-ui`)
 - [Fliplet Themes](API/fliplet-themes.md) (`fliplet-themes`)
 - [Fliplet UI](API/fliplet-ui.md) (`fliplet-pages`)
-- [Like Buttons](API/like-buttons.md) (`fliplet-like:0.2`)
+- [Like Buttons](API/like-buttons.md) (`fliplet-like:0.2`) (Beta)
 
 ---
 

--- a/docs/API/fliplet-content.md
+++ b/docs/API/fliplet-content.md
@@ -1,9 +1,5 @@
 # `Fliplet.Content()`
 
-## Related
-
-* [`Fliplet.Profile.Content()`](fliplet-profile-content.md)
-
 (Returns **`Promise`**)
 
 The `fliplet-content` package contains helpers to create and manage content using data sources.
@@ -33,6 +29,10 @@ Fliplet.Content(options)
   * **dataSourceId** (Number) The data source ID where the content will be stored.
   * **user** (Object) The user object to be used to identify a specific user. If set, content created will be stored with the provided user object. Query, update and delete actions will only work if the user object matches.
 
+## Related
+
+* [`Fliplet.Profile.Content()`](fliplet-profile-content.md) - Use `Fliplet.Profile,Content()` to create and manage content specific to the user.
+
 ## Examples
 
 ### Share a page with a URL
@@ -50,7 +50,7 @@ Fliplet.Content({dataSourceId: 2}).then(function (content) {
     var url = Fliplet.Env.get('appsUrl') + 'r/' + entry.data.publicSlug;
     // Show UI to share the URL
     Fliplet.Communicate.shareURL(url);
-  });  
+  });
 });
 ```
 

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -2,44 +2,44 @@
 
 The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
 
-**Note: The Fliplet OAuth2 library is Currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
+**Note: The Fliplet OAuth2 library is currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
 
-To configure an OAuth2 provider, call `Fliplet.OAuth2.configure()` with the provider specificaions and use `Fliplet.OAuth2(provider)` with the specified provider name to access the available methods, e.g. `Fliplet.OAuth2(provider).api(path)`.
+To configure an OAuth2 service provider, call `Fliplet.OAuth2.configure()` with the service specificaions and use `Fliplet.OAuth2(service)` with the specified service name to access the available methods, e.g. `Fliplet.OAuth2(service).api(path)`.
 
 ```js
-// Configure providers
-Fliplet.OAuth2.configure(provider, configuration);
-// Make API requests using configured provider
-Fliplet.OAuth2(provider).api(path)
+// Configure services
+Fliplet.OAuth2.configure(service, configuration);
+// Make API requests using configured service
+Fliplet.OAuth2(service).api(path)
   .then(function (response) {
-    // Process response from API provider as necessary
+    // Process response from API service as necessary
   });
 ```
 
 ## Examples
 
-### 1. Configure a connection with the GitHub provider
+### 1. Configure a connection with GitHub
 
-*Note: The provider configuration is likely executed via the Global JS code in Fliplet Studio.*
+*Note: The service configuration is likely executed via the Global JS code in Fliplet Studio.*
 
 ```js
 Flipet.OAuth2.configure('github', {
-  authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 provider
-  grantType: 'implicit', // as supported by OAuth2 provider
-  grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 provider
-  baseUrl: 'https://api.github.com/', // from OAuth2 provider
-  clientId: '4c867cd2a96541883322', // from OAuth2 provider
-  clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 provider
-  redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 provider
+  authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 service provider
+  grantType: 'implicit', // as supported by OAuth2 service provider
+  grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 service provider
+  baseUrl: 'https://api.github.com/', // from OAuth2 service provider
+  clientId: '4c867cd2a96541883322', // from OAuth2 service provider
+  clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 service provider
+  redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 service provider
   state: 'FeeIUo0hJv6K5l9-1', // optional state parameter during login
   loginPageId: 12345, // page ID where login page is found
   postLoginPageId: 12346 // page ID where users are redirected to after login
 });
 ```
 
-### 2. Log in using the configured GitHub provider
+### 2. Log in using the configured GitHub service
 
-*Note: The provider name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+*Note: The service name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
 ```js
 // Start login process
@@ -49,9 +49,9 @@ Fliplet.OAuth2('github').login()
   });
 ```
 
-### 3. Make API requests using the configured GitHub provider
+### 3. Make API requests using the configured GitHub service
 
-*Note: The provider name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+*Note: The service name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
 The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
 
@@ -60,9 +60,17 @@ The login page can process these query parameters via `Fliplet.Navigate.query` t
 ```js
 Fliplet.OAuth2('github').api('user')
   .then(function (response) {
-    // Process response from API provider as necessary
+    // Process response from API service as necessary
   });
 ```
+
+## Cross-Domain AJAX requests
+
+A common problem for developers is a browser to refuse access to a remote resource. Usually, this happens when you execute **AJAX cross domain request** using jQuery Ajax interface, Fetch API, or plain XMLHttpRequest. As result is that the AJAX request is not performed and data are not retrieved.
+
+This can occur with OAuth2 services if the service provider is not configured to allow Fliplet's app domains.
+
+Cross-Origin Request Sharing (CORS) sometimes needs to be configured with the service provider to ensure API requests can be made across domains. See [AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md) for more information.
 
 ## Methods
 
@@ -70,26 +78,28 @@ Fliplet.OAuth2('github').api('user')
 
 (Returns **`null`**)
 
-Configure an OAuth2 provider or multiple OAuth2 providers.
+Configure an OAuth2 service or multiple OAuth2 services.
 
 ```js
-Fliplet.OAuth2.configure(provider, configuration)
-Fliplet.OAuth2.configure(providers)
+Fliplet.OAuth2.configure(service, configuration)
+Fliplet.OAuth2.configure(services)
 ```
 
-* **provider** (String) **Required** A provider name. The provider name is used when making OAuth2 requests.
-* **configuration** (Object) **Required** A key-value map of options to configure providers with. Each object can contain the following details.
-  * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 provider.
+* **service** (String) **Required** A service name. The service name is used when making `Fliplet.OAuth2` requests.
+* **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
+  * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
   * **grantType** (String) `implicit|explicit` **Required** Implicit (token) or Explicit (code) Grant flow to be used when logging in.
-  * **grantUrl** (String) Grant URL as supplied by the OAuth2 provider. Required if an *Explicit Grant* flow is used when calling `.login()`.
+  * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *Explicit Grant* flow is used when calling `.login()`.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
-  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 provider.
-  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 provider.
-  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 provider. It's also called *authorization callback URL* by some OAuth2 providers. Fliplet provides `https://fliplet.com/oauth2-success` to show a generic login success message. You may use any custom page as necessary.
-  * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 provider during the redirect step for additional verification during login.
+  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
+  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
+  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://fliplet.com/oauth2-success` to show a generic login success message. You may use any custom page as necessary.
+  * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
   * **loginPageId** (Number) Page ID of login page.
   * **postLoginPagseId** (Number) Page ID of page to redirect to if user is logged in.
-* **providers** **Required** (Object) A key-value map of provider configurations to configure multiple providers in one go. Each provider configuration should use the provider name as the key and a configuration that follows the specification as outlined for the `configuration` parameter above.
+  * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
+  * **verifyRedirectUrl** (Function) An optional function that takes the redirect URL after login, and confirms if the URL is valid. The URL is passed as the first parameter and the function can either return a value or a Promise. If a Promise is returned, the URL is considered valid if the Promise resolves. If the Promise rejects, the URL is considered invalid.
+* **services** **Required** (Object) A key-value map of service configurations to configure multiple services in one go. Each service configuration should use the service name as the key and a configuration that follows the specification as outlined for the `configuration` parameter above.
 
 ### `Fliplet.OAuth2().login()`
 
@@ -98,32 +108,34 @@ Fliplet.OAuth2.configure(providers)
 Initialize the OAuth2 authentication process with the in-app browser.
 
 ```js
-Fliplet.OAuth2(provider).login()
+Fliplet.OAuth2(service).login()
 ```
 
-* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.configure()`.
+* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
 
 ### `Fliplet.OAuth2().logout()`
 
 (Returns **`Promise`**)
 
-Remove sessions with all providers or with specific providers as defined via `provider`.
+Logout and remove session with a specific service.
 
 ```js
-Fliplet.OAuth2(provider).logout()
+Fliplet.OAuth2(service).logout()
 ```
 
-* **provider** (String|Array) Provider name(s) as configured in `Fliplet.OAuth2.configure()`. Sessions in the specified provider(s) will be removed. If a `provider` is not given, all sessions will be removed.
+* **service** (String) Service name as configured in `Fliplet.OAuth2.configure()`. The currently active session in the specified service will be removed after the user has successfully logged out.
 
 ### `Fliplet.OAuth2().getAuthResponse()`
 
 (Returns **`Promise`**)
 
-Get the current status of sessions with all providers. This does not validate any sessions which may have expired. Sessions are returned in the Promise resolving function as key-value objects.
+Get the current status of sessions with a selected service. This does not validate any sessions which may have expired.
 
 ```js
-Fliplet.OAuth2().getAuthResponse()
+Fliplet.OAuth2(service).getAuthResponse()
 ```
+
+* **service** (String) Service name as configured in `Fliplet.OAuth2.configure()`.
 
 ### `Fliplet.OAuth2().api()`
 
@@ -134,14 +146,14 @@ Make calls to the API for getting and posting data.
 *Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.*
 
 ```js
-Fliplet.OAuth2(provider).api(path)
-Fliplet.OAuth2(provider).api(options)
+Fliplet.OAuth2(service).api(path)
+Fliplet.OAuth2(service).api(options)
 ```
 
-* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.configure()`.
-* **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
+* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
+* **path** (String) **Required** A relative path to the service base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored. *When using a single `path` parameter, the request will be made as a `GET` request.*
 * **options** (Object) **Required** A map of options to pass to the method.
-  * **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
+  * **path** (String) **Required** A relative path to the service base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
   * **method** (String) `get|post|put|delete` HTTP request method to use. **Default**: `GET`
   * **data** (Object) A JSON object of data, FormData, HTMLInputElement, HTMLFormElment to be sent along with a `get`, `post` or `put` request. **Default**: `null`
 

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -28,10 +28,10 @@ Flipet.OAuth2.configure('github', {
   grantType: 'implicit', // as supported by OAuth2 service provider
   grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 service provider
   baseUrl: 'https://api.github.com/', // from OAuth2 service provider
-  clientId: '4c867cd2a96541883322', // from OAuth2 service provider
-  clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 service provider
+  clientId: 'uztcbv3bwtkxmmej1lxv', // from OAuth2 service provider
+  clientSecret: 'jepbrhknlxjxriltyjrtprbevdfclnagn2uc1dsq', // from OAuth2 service provider
   redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 service provider
-  state: 'FeeIUo0hJv6K5l9-1', // optional state parameter during login
+  state: 'cbv3bwhJv6K5l9-1', // optional state parameter during login
   loginPageId: 12345, // page ID where login page is found
   postLoginPageId: 12346 // page ID where users are redirected to after login
 });

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -6,7 +6,7 @@ The `fliplet-oauth2` package contains helpers for standardizing requests to OAut
 
 **Note: The Fliplet OAuth2 library is Currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
 
-To configure a connection with an OAuth2 provider, initialize a connection with `Fliplet.OAuth2.init()` using a key-value object and use `Fliplet.OAuth2(name)` with the specified connection name to access the available methods.
+To configure a connection with an OAuth2 provider, initialize a connection with `Fliplet.OAuth2.init()` using a key-value object and use `Fliplet.OAuth2(provider)` with the specified provider name to access the available methods.
 
 ```js
 Fliplet.OAuth2.init(providers);

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -89,7 +89,7 @@ Fliplet.OAuth2.configure(services)
   * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
   * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-callback` to show a generic login success message. You may use any custom page as necessary.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
-  * **grantType** (String) `token|code` **Required** Choose to use *implicit* (token) or *explicit* (code) grant flow to be used when logging in. **Default**: `token`
+  * **grantType** (String) `token|code` **Required** Choose to use *implicit* (`token`) or *explicit* (`code`) grant flow to be used when logging in. **Default**: `token`
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *explicit grant* flow is used when calling `.login()`.
   * **grantData** (Object) A mapping object of data to pass to `grantUrl` when requesting an access token via the *explicit grant* flow.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -85,15 +85,15 @@ Fliplet.OAuth2.configure(services)
 
 * **service** (String) **Required** A service name. The service name is used when making `Fliplet.OAuth2` requests.
 * **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
+  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
+  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
+  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-callback` to show a generic login success message. You may use any custom page as necessary.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
   * **grantType** (String) `token|code` **Required** Choose to use *implicit* (token) or *explicit* (code) grant flow to be used when logging in. **Default**: `token`
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *explicit grant* flow is used when calling `.login()`.
   * **grantData** (Object) A mapping object of data to pass to `grantUrl` when requesting an access token via the *explicit grant* flow.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
   * **useProxy** (Boolean) Set as `true` to use Fliplet's proxy when granting access token using the *explicit* the grant flow and when making API requests. This may be necessary if the service is not configured to work with cross-domain AJAX requests. See **[AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md)** for more information. **Default**: `false`
-  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
-  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
-  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-callback` to show a generic login success message. You may use any custom page as necessary.
   * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
   * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
   * **refresh** (Boolean) Indicates that the OAuth2 service supports refreshing access tokens to keep them valid. **Default**: `false`
@@ -121,7 +121,7 @@ Logout and remove session with a specific service.
 Fliplet.OAuth2(service).logout()
 ```
 
-* **service** (String) Service name as configured in `Fliplet.OAuth2.configure()`. The currently active session in the specified service will be removed after the user has successfully logged out.
+* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`. The currently active session in the specified service will be removed after the user has successfully logged out.
 
 ### `Fliplet.OAuth2().getAuthResponse()`
 
@@ -133,7 +133,7 @@ Get the current status of sessions with a selected service. This does not valida
 Fliplet.OAuth2(service).getAuthResponse()
 ```
 
-* **service** (String) Service name as configured in `Fliplet.OAuth2.configure()`.
+* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
 
 ### `Fliplet.OAuth2().api()`
 
@@ -165,6 +165,7 @@ Add event listeners to OAuth2 responses.
 Fliplet.Oauth2(service).on(eventName, fn)
 ```
 
+* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
 * **eventName** (String) See **Events** below.
 * **fn** (Function) Event handler function to execute when event is fired.
 

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -87,7 +87,8 @@ Fliplet.OAuth2.configure(services)
 * **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
   * **grantType** (String) `token|code` **Required** Choose to use *implicit* (token) or *explicit* (code) grant flow to be used when logging in. **Default**: `token`
-  * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *Explicit Grant* flow is used when calling `.login()`.
+  * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *explicit grant* flow is used when calling `.login()`.
+  * **grantData** (Object) A mapping object of data to pass to `grantUrl` when requesting an access token via the *explicit grant* flow.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
   * **useProxy** (Boolean) Set as `true` to use Fliplet's proxy when granting access token using the *explicit* the grant flow and when making API requests. This may be necessary if the service is not configured to work with cross-domain AJAX requests. See **[AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md)** for more information. **Default**: `false`
   * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -53,9 +53,9 @@ Fliplet.OAuth2('github').login()
 
 *Note: The provider name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
-The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
+The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
 
-The login page can process these query parameters via `Fliplet.Navigste.query` to customize the user experience accordingly.
+The login page can process these query parameters via `Fliplet.Navigate.query` to customize the user experience accordingly.
 
 ```js
 Fliplet.OAuth2('github').api('user')
@@ -78,7 +78,7 @@ Fliplet.OAuth2.configure(providers)
 ```
 
 * **provider** (String) **Required** A provider name. The provider name is used when making OAuth2 requests.
-* **configuration** (Object) **Required** A key-value map of options to confgigure providers with. Each object can contain the following details.
+* **configuration** (Object) **Required** A key-value map of options to configure providers with. Each object can contain the following details.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 provider.
   * **grantType** (String) `implicit|explicit` **Required** Implicit (token) or Explicit (code) Grant flow to be used when logging in.
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 provider. Required if an *Explicit Grant* flow is used when calling `.login()`.
@@ -119,7 +119,7 @@ Fliplet.OAuth2(provider).logout()
 
 (Returns **`Promise`**)
 
-Get the current status of sessions with all providers. This is does not validate any sessions which may have expired. Sessions are returned in the Promise resolving function as key-value objects.
+Get the current status of sessions with all providers. This does not validate any sessions which may have expired. Sessions are returned in the Promise resolving function as key-value objects.
 
 ```js
 Fliplet.OAuth2().getAuthResponse()
@@ -131,7 +131,7 @@ Fliplet.OAuth2().getAuthResponse()
 
 Make calls to the API for getting and posting data.
 
-*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.*
+*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.*
 
 ```js
 Fliplet.OAuth2(provider).api(path)

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -86,12 +86,12 @@ Fliplet.OAuth2.configure(services)
 * **service** (String) **Required** A service name. The service name is used when making `Fliplet.OAuth2` requests.
 * **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
-  * **grantType** (String) `implicit|explicit` **Required** Implicit (token) or Explicit (code) Grant flow to be used when logging in.
+  * **grantType** (String) `token|code` **Required** Implicit (token) or Explicit (code) grant flow to be used when logging in. **Default**: `token`
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *Explicit Grant* flow is used when calling `.login()`.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
   * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
   * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
-  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://fliplet.com/oauth2-success` to show a generic login success message. You may use any custom page as necessary.
+  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-success` to show a generic login success message. You may use any custom page as necessary.
   * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
   * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
   * **refresh** (Boolean) Indicates that the OAuth2 service supports refreshing access tokens to keep them valid. **Default**: `false`
@@ -139,7 +139,7 @@ Fliplet.OAuth2(service).getAuthResponse()
 
 Make calls to the API for getting and posting data.
 
-*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.*
+*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if configured) before making API calls.*
 
 ```js
 Fliplet.OAuth2(service).api(path)

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -2,7 +2,7 @@
 
 The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
 
-**Note: The Fliplet OAuth2 library is currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
+**Note: The Fliplet OAuth2 library is currently in beta. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking when new versions of the feature are released.**
 
 To configure an OAuth2 service provider, call `Fliplet.OAuth2.configure()` with the service specificaions and use `Fliplet.OAuth2(service)` with the specified service name to access the available methods, e.g. `Fliplet.OAuth2(service).api(path)`.
 
@@ -86,9 +86,10 @@ Fliplet.OAuth2.configure(services)
 * **service** (String) **Required** A service name. The service name is used when making `Fliplet.OAuth2` requests.
 * **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
-  * **grantType** (String) `token|code` **Required** Implicit (token) or Explicit (code) grant flow to be used when logging in. **Default**: `token`
+  * **grantType** (String) `token|code` **Required** Choose to use *implicit* (token) or *explicit* (code) grant flow to be used when logging in. **Default**: `token`
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *Explicit Grant* flow is used when calling `.login()`.
   * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
+  * **useProxy** (Boolean) Set as `true` to use Fliplet's proxy when granting access token using the *explicit* the grant flow and when making API requests. This may be necessary if the service is not configured to work with cross-domain AJAX requests. See **[AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md)** for more information. **Default**: `false`
   * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
   * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
   * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-success` to show a generic login success message. You may use any custom page as necessary.

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -9,7 +9,13 @@ The `fliplet-oauth2` package contains helpers for standardizing requests to OAut
 To configure a connection with an OAuth2 provider, initialize a connection with `Fliplet.OAuth2.init()` using a key-value object and use `Fliplet.OAuth2(provider)` with the specified provider name to access the available methods.
 
 ```js
+// Initialize providers
 Fliplet.OAuth2.init(providers);
+// Make API requests using configured provider
+Fliplet.OAuth2(provider).api(path)
+  .then(function (response) {
+    // Process response from API provider as necessary
+  });
 ```
 
 ## Examples
@@ -56,11 +62,10 @@ The Fliplet OAuth2 library will manage authentication tokens and any token refre
 The login page can process these query parameters via `Fliplet.Navigste.query` to customize the user experience accordingly.
 
 ```js
-Fliplet.OAuth2('github').api({
-  path: 'user'
-}).then(function (response) {
-  // Process response from API provider as necessary
-});
+Fliplet.OAuth2('github').api('user')
+  .then(function (response) {
+    // Process response from API provider as necessary
+  });
 ```
 
 ## Methods

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -45,7 +45,7 @@ Flipet.OAuth2.configure('github', {
 // Start login process
 Fliplet.OAuth2('github').login()
   .then(function () {
-    // Successfull logged in
+    // Successfully logged in
   });
 ```
 

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -1,0 +1,149 @@
+# `Fliplet.OAuth2()` (Beta)
+
+(Returns **`Promise`**)
+
+The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
+
+**Note: The Fliplet OAuth2 library is Currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
+
+To configure a connection with an OAuth2 provider, initialize a connection with `Fliplet.OAuth2.init()` using a key-value object and use `Fliplet.OAuth2(name)` with the specified connection name to access the available methods.
+
+```js
+Fliplet.OAuth2.init(providers);
+```
+
+## Examples
+
+### 1. Initialize a connection with the GitHub provider
+
+*Note: The provider initialization is likely executed via the Global JS code in Fliplet Studio.*
+
+```js
+Flipet.OAuth2.init({
+  github: {
+    authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 provider
+    grantType: 'implicit', // as supported by OAuth2 provider
+    grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 provider
+    baseUrl: 'https://api.github.com/', // from OAuth2 provider
+    clientId: '4c867cd2a96541883322', // from OAuth2 provider
+    clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 provider
+    redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 provider
+    state: 'FeeIUo0hJv6K5l9-1', // optional state parameter during login
+    loginPageId: 12345, // page ID where login page is found
+    postLoginPageId: 12346 // page ID where users are redirected to after login
+  }
+});
+```
+
+### 2. Log in using the configured GitHub provider
+
+*Note: The provider name as configured through `Fliplet.OAuth2.init()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+
+```js
+// Start login process
+Fliplet.OAuth2('github').login()
+  .then(function () {
+    // Successfull logged in
+  });
+```
+
+### 3. Make API requests using the configured GitHub provider
+
+*Note: The provider name as configured through `Fliplet.OAuth2.init()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+
+The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
+
+The login page can process these query parameters via `Fliplet.Navigste.query` to customize the user experience accordingly.
+
+```js
+Fliplet.OAuth2('github').api({
+  path: 'user'
+}).then(function (response) {
+  // Process response from API provider as necessary
+});
+```
+
+## Methods
+
+### `Fliplet.OAuth2.init()`
+
+(Returns **`null`**)
+
+Initialize a connection with an OAuth2 provider.
+
+```js
+Fliplet.OAuth2.init(providers)
+```
+
+* **providers** (Object) A key-value map of options to initialize connections with. Each object can contain the following details.
+  * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 provider.
+  * **grantType** (String) `implicit|explicit` **Required** Implicit (token) or Explicit (code) Grant flow to be used when logging in.
+  * **grantUrl** (String) Grant URL as supplied by the OAuth2 provider. Required if an *Explicit Grant* flow is used when calling `.login()`.
+  * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
+  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 provider.
+  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 provider.
+  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 provider. It's also called *authorization callback URL* by some OAuth2 providers. Fliplet provides `https://fliplet.com/oauth2-success` to show a generic login success message. You may use any custom page as necessary.
+  * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 provider during the redirect step for additional verification during login.
+  * **loginPageId** (Number) Page ID of login page.
+  * **postLoginPagseId** (Number) Page ID of page to redirect to if user is logged in.
+
+### `Fliplet.OAuth2().login()`
+
+(Returns **`Promise`**)
+
+Initialize the OAuth2 authentication process with the in-app browser.
+
+```js
+Fliplet.OAuth2(provider).login()
+```
+
+* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
+
+### `Fliplet.OAuth2().logout()`
+
+(Returns **`Promise`**)
+
+Remove sessions with all providers or with specific providers as defined via `provider`.
+
+```js
+Fliplet.OAuth2(provider).logout()
+```
+
+* **provider** (String|Array) Provider name(s) as configured in `Fliplet.OAuth2.init()`. Sessions in the specified provider(s) will be removed. If a `provider` is not given, all sessions will be removed.
+
+### `Fliplet.OAuth2().getAuthResponse()`
+
+(Returns **`Promise`**)
+
+Get the current status of sessions with all providers. This is does not validate any sessions which may have expired. Sessions are returned in the Promise resolving function as key-value objects.
+
+```js
+Fliplet.OAuth2().getAuthResponse()
+```
+
+### `Fliplet.OAuth2().api()`
+
+(Returns **`Promise`**)
+
+Make calls to the API for getting and posting data.
+
+```js
+Fliplet.OAuth2(provider).api(path)
+```
+
+* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
+* **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.init()` or a full URL. If a full URL is provided the base URL will be ignored.
+
+
+```js
+Fliplet.OAuth2(provider).api(options)
+```
+
+* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
+* **options** (Object) **Required** A map of options to pass to the method.
+  * **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.init()` or a full URL. If a full URL is provided the base URL will be ignored.
+  * **method** (String) `get|post|put|delete` HTTP request method to use. **Default**: `GET`
+  * **data** (Object) A JSON object of data, FormData, HTMLInputElement, HTMLFormElment to be sent along with a `get`, `post` or `put` request. **Default**: `null`
+
+[Back to API documentation](../API-Documentation.md)
+{: .buttons}

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -1,16 +1,14 @@
-# `Fliplet.OAuth2()` (Beta)
-
-(Returns **`Promise`**)
+# `Fliplet.OAuth2` (Beta)
 
 The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
 
 **Note: The Fliplet OAuth2 library is Currently in beta and only works in native apps. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking as the feature undergoes further development.**
 
-To configure a connection with an OAuth2 provider, initialize a connection with `Fliplet.OAuth2.init()` using a key-value object and use `Fliplet.OAuth2(provider)` with the specified provider name to access the available methods.
+To configure an OAuth2 provider, call `Fliplet.OAuth2.configure()` with the provider specificaions and use `Fliplet.OAuth2(provider)` with the specified provider name to access the available methods, e.g. `Fliplet.OAuth2(provider).api(path)`.
 
 ```js
-// Initialize providers
-Fliplet.OAuth2.init(providers);
+// Configure providers
+Fliplet.OAuth2.configure(provider, configuration);
 // Make API requests using configured provider
 Fliplet.OAuth2(provider).api(path)
   .then(function (response) {
@@ -20,30 +18,28 @@ Fliplet.OAuth2(provider).api(path)
 
 ## Examples
 
-### 1. Initialize a connection with the GitHub provider
+### 1. Configure a connection with the GitHub provider
 
-*Note: The provider initialization is likely executed via the Global JS code in Fliplet Studio.*
+*Note: The provider configuration is likely executed via the Global JS code in Fliplet Studio.*
 
 ```js
-Flipet.OAuth2.init({
-  github: {
-    authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 provider
-    grantType: 'implicit', // as supported by OAuth2 provider
-    grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 provider
-    baseUrl: 'https://api.github.com/', // from OAuth2 provider
-    clientId: '4c867cd2a96541883322', // from OAuth2 provider
-    clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 provider
-    redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 provider
-    state: 'FeeIUo0hJv6K5l9-1', // optional state parameter during login
-    loginPageId: 12345, // page ID where login page is found
-    postLoginPageId: 12346 // page ID where users are redirected to after login
-  }
+Flipet.OAuth2.configure('github', {
+  authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 provider
+  grantType: 'implicit', // as supported by OAuth2 provider
+  grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 provider
+  baseUrl: 'https://api.github.com/', // from OAuth2 provider
+  clientId: '4c867cd2a96541883322', // from OAuth2 provider
+  clientSecret: '5f66b7a07842570936512097ec255721b259b16a', // from OAuth2 provider
+  redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 provider
+  state: 'FeeIUo0hJv6K5l9-1', // optional state parameter during login
+  loginPageId: 12345, // page ID where login page is found
+  postLoginPageId: 12346 // page ID where users are redirected to after login
 });
 ```
 
 ### 2. Log in using the configured GitHub provider
 
-*Note: The provider name as configured through `Fliplet.OAuth2.init()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+*Note: The provider name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
 ```js
 // Start login process
@@ -55,7 +51,7 @@ Fliplet.OAuth2('github').login()
 
 ### 3. Make API requests using the configured GitHub provider
 
-*Note: The provider name as configured through `Fliplet.OAuth2.init()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
+*Note: The provider name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
 The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
 
@@ -70,17 +66,19 @@ Fliplet.OAuth2('github').api('user')
 
 ## Methods
 
-### `Fliplet.OAuth2.init()`
+### `Fliplet.OAuth2.configure()`
 
 (Returns **`null`**)
 
-Initialize a connection with an OAuth2 provider.
+Configure an OAuth2 provider or multiple OAuth2 providers.
 
 ```js
-Fliplet.OAuth2.init(providers)
+Fliplet.OAuth2.configure(provider, configuration)
+Fliplet.OAuth2.configure(providers)
 ```
 
-* **providers** (Object) A key-value map of options to initialize connections with. Each object can contain the following details.
+* **provider** (String) **Required** A provider name. The provider name is used when making OAuth2 requests.
+* **configuration** (Object) **Required** A key-value map of options to confgigure providers with. Each object can contain the following details.
   * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 provider.
   * **grantType** (String) `implicit|explicit` **Required** Implicit (token) or Explicit (code) Grant flow to be used when logging in.
   * **grantUrl** (String) Grant URL as supplied by the OAuth2 provider. Required if an *Explicit Grant* flow is used when calling `.login()`.
@@ -91,6 +89,7 @@ Fliplet.OAuth2.init(providers)
   * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 provider during the redirect step for additional verification during login.
   * **loginPageId** (Number) Page ID of login page.
   * **postLoginPagseId** (Number) Page ID of page to redirect to if user is logged in.
+* **providers** **Required** (Object) A key-value map of provider configurations to configure multiple providers in one go. Each provider configuration should use the provider name as the key and a configuration that follows the specification as outlined for the `configuration` parameter above.
 
 ### `Fliplet.OAuth2().login()`
 
@@ -102,7 +101,7 @@ Initialize the OAuth2 authentication process with the in-app browser.
 Fliplet.OAuth2(provider).login()
 ```
 
-* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
+* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.configure()`.
 
 ### `Fliplet.OAuth2().logout()`
 
@@ -114,7 +113,7 @@ Remove sessions with all providers or with specific providers as defined via `pr
 Fliplet.OAuth2(provider).logout()
 ```
 
-* **provider** (String|Array) Provider name(s) as configured in `Fliplet.OAuth2.init()`. Sessions in the specified provider(s) will be removed. If a `provider` is not given, all sessions will be removed.
+* **provider** (String|Array) Provider name(s) as configured in `Fliplet.OAuth2.configure()`. Sessions in the specified provider(s) will be removed. If a `provider` is not given, all sessions will be removed.
 
 ### `Fliplet.OAuth2().getAuthResponse()`
 
@@ -132,21 +131,17 @@ Fliplet.OAuth2().getAuthResponse()
 
 Make calls to the API for getting and posting data.
 
+*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.*
+
 ```js
 Fliplet.OAuth2(provider).api(path)
-```
-
-* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
-* **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.init()` or a full URL. If a full URL is provided the base URL will be ignored.
-
-
-```js
 Fliplet.OAuth2(provider).api(options)
 ```
 
-* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.init()`.
+* **provider** (String) **Required** Provider name as configured in `Fliplet.OAuth2.configure()`.
+* **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
 * **options** (Object) **Required** A map of options to pass to the method.
-  * **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.init()` or a full URL. If a full URL is provided the base URL will be ignored.
+  * **path** (String) **Required** A relative path to the provider base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
   * **method** (String) `get|post|put|delete` HTTP request method to use. **Default**: `GET`
   * **data** (Object) A JSON object of data, FormData, HTMLInputElement, HTMLFormElment to be sent along with a `get`, `post` or `put` request. **Default**: `null`
 

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -31,9 +31,7 @@ Flipet.OAuth2.configure('github', {
   clientId: 'uztcbv3bwtkxmmej1lxv', // from OAuth2 service provider
   clientSecret: 'jepbrhknlxjxriltyjrtprbevdfclnagn2uc1dsq', // from OAuth2 service provider
   redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 service provider
-  state: 'cbv3bwhJv6K5l9-1', // optional state parameter during login
-  loginPageId: 12345, // page ID where login page is found
-  postLoginPageId: 12346 // page ID where users are redirected to after login
+  state: 'cbv3bwhJv6K5l9-1' // optional state parameter during login
 });
 ```
 
@@ -44,8 +42,8 @@ Flipet.OAuth2.configure('github', {
 ```js
 // Start login process
 Fliplet.OAuth2('github').login()
-  .then(function () {
-    // Successfully logged in
+  .then(function (response) {
+    // Authentication response is cached and returned
   });
 ```
 
@@ -53,7 +51,7 @@ Fliplet.OAuth2('github').login()
 
 *Note: The service name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*
 
-The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if supported) before making API calls. If the token is invalid or missing, the user will be redirected to the login page with a `tokenInvalid=true` or `tokenMissing=true` query parameter respectively.
+The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if configured) before making API calls.
 
 The login page can process these query parameters via `Fliplet.Navigate.query` to customize the user experience accordingly.
 
@@ -95,10 +93,8 @@ Fliplet.OAuth2.configure(services)
   * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
   * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://fliplet.com/oauth2-success` to show a generic login success message. You may use any custom page as necessary.
   * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
-  * **loginPageId** (Number) Page ID of login page.
-  * **postLoginPagseId** (Number) Page ID of page to redirect to if user is logged in.
   * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
-  * **verifyRedirectUrl** (Function) An optional function that takes the redirect URL after login, and confirms if the URL is valid. The URL is passed as the first parameter and the function can either return a value or a Promise. If a Promise is returned, the URL is considered valid if the Promise resolves. If the Promise rejects, the URL is considered invalid.
+  * **refresh** (Boolean) Indicates that the OAuth2 service supports refreshing access tokens to keep them valid. **Default**: `false`
 * **services** **Required** (Object) A key-value map of service configurations to configure multiple services in one go. Each service configuration should use the service name as the key and a configuration that follows the specification as outlined for the `configuration` parameter above.
 
 ### `Fliplet.OAuth2().login()`
@@ -156,6 +152,25 @@ Fliplet.OAuth2(service).api(options)
   * **path** (String) **Required** A relative path to the service base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
   * **method** (String) `get|post|put|delete` HTTP request method to use. **Default**: `GET`
   * **data** (Object) A JSON object of data, FormData, HTMLInputElement, HTMLFormElment to be sent along with a `get`, `post` or `put` request. **Default**: `null`
+
+### `Fliplet.OAuth2().on()`
+
+(Returns **`null`**)
+
+Add event listeners to OAuth2 responses.
+
+```js
+Fliplet.Oauth2(service).on(eventName, fn)
+```
+
+* **eventName** (String) See **Events** below.
+* **fn** (Function) Event handler function to execute when event is fired.
+
+## Events
+
+* **auth.login** User is successfully logged in. The authentication response is passed to the event handler function.
+* **auth.fail** User fails to log in. The error response is passed to the event handler function.
+* **auth.logout** User is successfully logged out.
 
 [Back to API documentation](../API-Documentation.md)
 {: .buttons}

--- a/docs/API/fliplet-oauth2.md
+++ b/docs/API/fliplet-oauth2.md
@@ -92,7 +92,7 @@ Fliplet.OAuth2.configure(services)
   * **useProxy** (Boolean) Set as `true` to use Fliplet's proxy when granting access token using the *explicit* the grant flow and when making API requests. This may be necessary if the service is not configured to work with cross-domain AJAX requests. See **[AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md)** for more information. **Default**: `false`
   * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
   * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
-  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-success` to show a generic login success message. You may use any custom page as necessary.
+  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-callback` to show a generic login success message. You may use any custom page as necessary.
   * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
   * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
   * **refresh** (Boolean) Indicates that the OAuth2 service supports refreshing access tokens to keep them valid. **Default**: `false`

--- a/docs/API/like-buttons.md
+++ b/docs/API/like-buttons.md
@@ -67,9 +67,9 @@ LikeButton(options)
       * `prepend` Like button is prepended to the `target` element(s)
       * `html` Like button is set as the content of the `target` element(s)
     * (Function) Use a custom function to add the button to the container. Return `false` to avoid adding the button entirely. **Note**: `target` is not required if `addType` is a function.
-  * `likeLabel` (String) Label of button to use when the rendering the like button before it's liked. **Default**: `<i class="fa fa-thumbs-o-up"></i> Like {{#if count}}{{count}}{{/if}}` The string will be used as a Handlebars template with the following variables:
+  * `likeLabel` (String) Label of button to use when the rendering the like button before it's liked. **Default**: {% raw %}`<i class="fa fa-thumbs-o-up"></i> Like {{#if count}}{{count}}{{/if}}`{% endraw %} The string will be used as a Handlebars template with the following variables:
     * `count` Number of likes
-  * `likedLabel` (String) Label of button to use when the rendering the like button after it's liked. **Default**: `<i class="fa fa-thumbs-up"></i> Like {{#if count}}{{count}}{{/if}}` The string will be used as a Handlebars template with the following variables:
+  * `likedLabel` (String) Label of button to use when the rendering the like button after it's liked. **Default**: {% raw %}`<i class="fa fa-thumbs-up"></i> Like {{#if count}}{{count}}{{/if}}`{% endraw %} The string will be used as a Handlebars template with the following variables:
     * `count` Number of likes
   * `likeWrapper` (String) HTML to use when wrapping the like button. **Default**: `<a class="btn btn-like" href="#"></a>`
   * `likedWrapper` (String) HTML to use when wrapping the liked button. **Default**: `<a class="btn btn-like" href="#"></a>`

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ To get a brief introduction to the technologies we use and the stack of the plat
   - [Securing your screens](Screen-security.md)
   - [Using async/await for more readable promises](Async-await.md)
   - [Custom HTML template for components](Custom-template-for-components.md)
+  - [Making AJAX across different domains](AJAX-cross-domain.md)
 11. Platform-specific advanced functionalities
   - [iOS](Platform-iOS.md)
   - [Android](Platform-Android.md)


### PR DESCRIPTION
# `Fliplet.OAuth2` (Beta)

The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.

**Note: The Fliplet OAuth2 library is currently in beta. We suggest specifying the library version using `fliplet-oauth2:0.1` when including the Fliplet OAuth2 library to avoid the functionality breaking when new versions of the feature are released.**

To configure an OAuth2 service provider, call `Fliplet.OAuth2.configure()` with the service specificaions and use `Fliplet.OAuth2(service)` with the specified service name to access the available methods, e.g. `Fliplet.OAuth2(service).api(path)`.

```js
// Configure services
Fliplet.OAuth2.configure(service, configuration);
// Make API requests using configured service
Fliplet.OAuth2(service).api(path)
  .then(function (response) {
    // Process response from API service as necessary
  });
```

## Examples

### 1. Configure a connection with GitHub

*Note: The service configuration is likely executed via the Global JS code in Fliplet Studio.*

```js
Flipet.OAuth2.configure('github', {
  authUrl: 'http://github.com/login/oauth/authorize', // from OAuth2 service provider
  grantType: 'implicit', // as supported by OAuth2 service provider
  grantUrl: 'https://github.com/login/oauth/access_token', // from OAuth2 service provider
  baseUrl: 'https://api.github.com/', // from OAuth2 service provider
  clientId: 'uztcbv3bwtkxmmej1lxv', // from OAuth2 service provider
  clientSecret: 'jepbrhknlxjxriltyjrtprbevdfclnagn2uc1dsq', // from OAuth2 service provider
  redirectUrl: 'https://fliplet.com/oauth2-success', // as configured with OAuth2 service provider
  state: 'cbv3bwhJv6K5l9-1' // optional state parameter during login
});
```

### 2. Log in using the configured GitHub service

*Note: The service name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*

```js
// Start login process
Fliplet.OAuth2('github').login()
  .then(function (response) {
    // Authentication response is cached and returned
  });
```

### 3. Make API requests using the configured GitHub service

*Note: The service name as configured through `Fliplet.OAuth2.configure()` is passed to `Fliplet.OAuth2()` to make sure the correct connection configurations are used.*

The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if configured) before making API calls.

The login page can process these query parameters via `Fliplet.Navigate.query` to customize the user experience accordingly.

```js
Fliplet.OAuth2('github').api('user')
  .then(function (response) {
    // Process response from API service as necessary
  });
```

## Cross-Domain AJAX requests

A common problem for developers is a browser to refuse access to a remote resource. Usually, this happens when you execute **AJAX cross domain request** using jQuery Ajax interface, Fetch API, or plain XMLHttpRequest. As result is that the AJAX request is not performed and data are not retrieved.

This can occur with OAuth2 services if the service provider is not configured to allow Fliplet's app domains.

Cross-Origin Request Sharing (CORS) sometimes needs to be configured with the service provider to ensure API requests can be made across domains. See [AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md) for more information.

## Methods

### `Fliplet.OAuth2.configure()`

(Returns **`null`**)

Configure an OAuth2 service or multiple OAuth2 services.

```js
Fliplet.OAuth2.configure(service, configuration)
Fliplet.OAuth2.configure(services)
```

* **service** (String) **Required** A service name. The service name is used when making `Fliplet.OAuth2` requests.
* **configuration** (Object) **Required** A key-value map of options to configure multiple services with. Each object can contain the following details.
  * **clientId** (String) **Required** Client ID as supplied by the OAuth2 service.
  * **clientSecret** (String) **Required** Client Secret as supplied by the OAuth2 service.
  * **redirectUrl** (String) **Required** Full page URL where users will be redirected to after a successful login through the OAuth2 service. It's also called *authorization callback URL* by some OAuth2 services. Fliplet provides `https://api.fliplet.com/v1/auth/sso-callback` to show a generic login success message. You may use any custom page as necessary.
  * **authUrl** (String) **Required** Authorization URL as supplied by the OAuth2 service.
  * **grantType** (String) `token|code` **Required** Choose to use *implicit* (token) or *explicit* (code) grant flow to be used when logging in. **Default**: `token`
  * **grantUrl** (String) Grant URL as supplied by the OAuth2 service. Required if an *explicit grant* flow is used when calling `.login()`.
  * **grantData** (Object) A mapping object of data to pass to `grantUrl` when requesting an access token via the *explicit grant* flow.
  * **baseUrl** (String) Base URL for API requests. API requests made with a full URL will ignore the `baseUrl`. If `baseUrl` is not provided, API requests are expected to be called using a full URL.
  * **useProxy** (Boolean) Set as `true` to use Fliplet's proxy when granting access token using the *explicit* the grant flow and when making API requests. This may be necessary if the service is not configured to work with cross-domain AJAX requests. See **[AJAX cross domain and cross-origin requests](../AJAX-cross-domain.md)** for more information. **Default**: `false`
  * **state** (String) `state` is an optional parameter that, if provided, is returned by the OAuth2 service during the redirect step for additional verification during login.
  * **scope** (String) A comma separated string of scopes as provided by the OAuth2 service.
  * **refresh** (Boolean) Indicates that the OAuth2 service supports refreshing access tokens to keep them valid. **Default**: `false`
* **services** **Required** (Object) A key-value map of service configurations to configure multiple services in one go. Each service configuration should use the service name as the key and a configuration that follows the specification as outlined for the `configuration` parameter above.

### `Fliplet.OAuth2().login()`

(Returns **`Promise`**)

Initialize the OAuth2 authentication process with the in-app browser.

```js
Fliplet.OAuth2(service).login()
```

* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.

### `Fliplet.OAuth2().logout()`

(Returns **`Promise`**)

Logout and remove session with a specific service.

```js
Fliplet.OAuth2(service).logout()
```

* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`. The currently active session in the specified service will be removed after the user has successfully logged out.

### `Fliplet.OAuth2().getAuthResponse()`

(Returns **`Promise`**)

Get the current status of sessions with a selected service. This does not validate any sessions which may have expired.

```js
Fliplet.OAuth2(service).getAuthResponse()
```

* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.

### `Fliplet.OAuth2().api()`

(Returns **`Promise`**)

Make calls to the API for getting and posting data.

*Note: The Fliplet OAuth2 library will manage authentication tokens and any token refreshing (if configured) before making API calls.*

```js
Fliplet.OAuth2(service).api(path)
Fliplet.OAuth2(service).api(options)
```

* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
* **path** (String) **Required** A relative path to the service base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored. *When using a single `path` parameter, the request will be made as a `GET` request.*
* **options** (Object) **Required** A map of options to pass to the method.
  * **path** (String) **Required** A relative path to the service base URL as configued in `Fliplet.OAuth2.configure()` or a full URL. If a full URL is provided the base URL will be ignored.
  * **method** (String) `get|post|put|delete` HTTP request method to use. **Default**: `GET`
  * **data** (Object) A JSON object of data, FormData, HTMLInputElement, HTMLFormElment to be sent along with a `get`, `post` or `put` request. **Default**: `null`

### `Fliplet.OAuth2().on()`

(Returns **`null`**)

Add event listeners to OAuth2 responses.

```js
Fliplet.Oauth2(service).on(eventName, fn)
```

* **service** (String) **Required** Service name as configured in `Fliplet.OAuth2.configure()`.
* **eventName** (String) See **Events** below.
* **fn** (Function) Event handler function to execute when event is fired.

## Events

* **auth.login** User is successfully logged in. The authentication response is passed to the event handler function.
* **auth.fail** User fails to log in. The error response is passed to the event handler function.
* **auth.logout** User is successfully logged out.
