### PR TITLE
consistent line breaks for handlebars

### DIFF
--- a/lib/gruntfile.js
+++ b/lib/gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
       dist: {
         options: {
           namespace: 'Fliplet.Widget.Templates',
+          processContent: function(src) { return src.replace(/\r\n/g, "\n"); },
           processName: function(filePath) {
             const fileName = filePath
               .replace(/^js\//, '')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "5.0.1",
+  "version": "5.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Command line utility for creating and running components, themes and menus to be used on the Fliplet platform.",
   "main": "fliplet.js",
   "scripts": {
@@ -11,7 +11,7 @@
   "bin": {
     "fliplet": "./fliplet.js"
   },
-  "homepage": "https://www.fliplet.com",
+  "homepage": "https://developers.fliplet.com",
   "repository": "Fliplet/fliplet-cli",
   "dependencies": {
     "archiver": "^3.0.0",


### PR DESCRIPTION
Outsourced team reported the compiler outputs `\r\n` instead of `\n` when running on Windows.