### PR TITLE
ID-2845 [FEAT] Add afterFormEntryLoad hook information in documentation

### DIFF
--- a/docs/API/components/form-builder.md
+++ b/docs/API/components/form-builder.md
@@ -460,6 +460,15 @@ Fliplet.Hooks.on('onFormSubmitError', function(error) {
 });
 ```
 
+### afterFormEntryLoad
+
+Runs when a form loads, and gets entryID of record.
+
+```js
+Fliplet.Hooks.on('afterFormEntryLoad', function(data) {
+  // form loads and gets entryID
+});
+```
 ### beforeRichFieldInitialize
 
 Runs when a **Rich text** field type is about to initialize. You can use this hook to make changes to the `config` initialization object which is then passed to **TinyMCE** after the hook runs.

--- a/docs/API/components/form-builder.md
+++ b/docs/API/components/form-builder.md
@@ -469,6 +469,7 @@ Fliplet.Hooks.on('afterFormEntryLoad', function(data) {
   // form loads and gets entryID
 });
 ```
+
 ### beforeRichFieldInitialize
 
 Runs when a **Rich text** field type is about to initialize. You can use this hook to make changes to the `config` initialization object which is then passed to **TinyMCE** after the hook runs.


### PR DESCRIPTION
**Product areas affected**

Studio -> Form -> Form Fields

**What does this PR do?**

Implemented code, so entry data available on frontend after loading the form with dataSourceEntryId passed to it

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/ID-2845)

**Result**

https://github.com/Fliplet/fliplet-widget-form-builder/assets/108272606/62e5e3c9-d685-4c95-9fd6-2adee0f919e6

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None
