### PR TITLE
ID-3530 [Fix] Ensure "pause" and "resume" events are not fired when interacting with app badge API on Android

### DIFF
--- a/docs/Native-framework-changelog.md
+++ b/docs/Native-framework-changelog.md
@@ -14,7 +14,7 @@ We regularly update our framework to support new features. If you have an older 
   <div class="bl two">
     <div>
       <h4>Android</h4>
-      <p>Current release: <u>6.3.1</u></p>
+      <p>Current release: <u>6.3.2</u></p>
       <p>Target API level: 33</p>
     </div>
   </div>
@@ -24,6 +24,10 @@ We regularly update our framework to support new features. If you have an older 
 ---
 
 ## Supported versions
+
+### Version 6.3.2 (September 13, 2023)
+
+- **Android**: Change AlarmManager API to use inexact alarm functions to schedule local notification.
 
 ### Version 6.3.1 (August 29, 2023)
 


### PR DESCRIPTION
### Product areas affected

JS API for Notification and local notification

### What does this PR do?

Fix issue of "pause" and "resume" events are fired when checking the notification permission for the app and changed the permission required for using Alarm Manager API used to schedule local notification.

### JIRA ticket

[ID-3530](https://weboo.atlassian.net/browse/ID-3530)


[ID-2973]: https://weboo.atlassian.net/browse/ID-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ID-3530]: https://weboo.atlassian.net/browse/ID-3530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ