### PR TITLE
DEV-1090: feat(login): migrate to unified auth flow

### DIFF
--- a/docs/API-Documentation.md
+++ b/docs/API-Documentation.md
@@ -77,6 +77,7 @@ These JS APIs falls into the most common category and almost all apps, component
 
   - [Audio](API/fliplet-audio.md) (`fliplet-audio`)
   - [Audio Player](API/fliplet-audio-player.md) (`fliplet-audio-player`)
+  - [Auth](API/fliplet-auth.md) (`fliplet-auth`)
   - [Barcode](API/fliplet-barcode.md) (`fliplet-barcode`)
   - [Communicate](API/fliplet-communicate.md) (`fliplet-communicate`)
   - [Content](API/fliplet-content.md) (`fliplet-content`)

--- a/docs/API/fliplet-auth.md
+++ b/docs/API/fliplet-auth.md
@@ -1,0 +1,210 @@
+# Auth JS APIs
+
+The Fliplet Auth JS APIs let you sign users into your Fliplet app with one line of code. It opens the unified sign-in popup (served by the Fliplet API) and handles the round-trip for you — including email/password and SSO (Google, Microsoft, Apple).
+
+Use these APIs to:
+
+- Sign users into your app with their Fliplet account
+- Read the currently signed-in user
+- Sign users out
+- Get the auth token for custom API calls
+- React to sign-in / sign-out events
+
+Add the `fliplet-auth` package to your app's dependencies to enable these APIs.
+
+---
+
+## Methods
+
+### Sign a user in
+
+Opens the unified sign-in popup. Resolves with `{ user, token }` when the user successfully signs in.
+
+```js
+Fliplet.Auth.signIn().then(function(result) {
+  console.log('Signed in as', result.user.email);
+  console.log('Auth token:', result.token);
+});
+```
+
+Pre-fill the email field in the sign-in form:
+
+```js
+Fliplet.Auth.signIn({ email: 'user@example.com' });
+```
+
+The promise rejects with an `Error` when:
+
+- The popup is blocked by the browser
+- The user closes the popup without completing sign-in
+- The sign-in times out (10 minutes)
+- The API returns an error (invalid credentials, 2FA flow cannot complete, etc.)
+
+```js
+Fliplet.Auth.signIn().then(function(result) {
+  // user signed in
+}).catch(function(err) {
+  console.error(err.message);
+});
+```
+
+---
+
+### Get the currently signed-in user
+
+Resolves to the signed-in user, or `null` when no user is signed in.
+
+```js
+Fliplet.Auth.currentUser().then(function(user) {
+  if (!user) {
+    // not signed in
+    return;
+  }
+
+  // contains id, email, userRoleId, region
+  console.log(user);
+});
+```
+
+---
+
+### Check whether a user is signed in
+
+A convenience helper that resolves to a boolean.
+
+```js
+Fliplet.Auth.isSignedIn().then(function(isSignedIn) {
+  if (isSignedIn) {
+    // user is signed in
+  }
+});
+```
+
+---
+
+### Get the user's auth token
+
+Resolves to the signed-in user's auth token, or `null` when no user is signed in. Use it to authenticate custom API calls as the signed-in user.
+
+```js
+Fliplet.Auth.getToken().then(function(token) {
+  return fetch(url, {
+    headers: { 'Auth-Token': token }
+  });
+});
+```
+
+---
+
+### Sign the user out
+
+Clears locally stored credentials and invalidates the server-side session.
+
+```js
+Fliplet.Auth.signOut().then(function() {
+  // user is signed out
+});
+```
+
+---
+
+### Listen for sign-in / sign-out events
+
+Subscribe to auth state changes. The callback fires with the new user after a successful sign-in, or with `null` after sign-out completes.
+
+```js
+var unsubscribe = Fliplet.Auth.onChange(function(user) {
+  if (user) {
+    // user just signed in
+  } else {
+    // user just signed out
+  }
+});
+
+// Stop listening when you no longer need to
+unsubscribe();
+```
+
+---
+
+## Examples
+
+### Gate a screen behind sign-in
+
+Prompt the user to sign in if they're not already signed in, then continue with the rest of the screen.
+
+```js
+Fliplet.Auth.currentUser().then(function(user) {
+  if (user) return user;
+  return Fliplet.Auth.signIn().then(function(result) {
+    return result.user;
+  });
+}).then(function(user) {
+  // render the screen as this user
+});
+```
+
+### Show the signed-in user's name in the header
+
+```js
+Fliplet.Auth.currentUser().then(function(user) {
+  var greeting = user
+    ? 'Welcome, ' + user.email
+    : 'Sign in to continue';
+
+  document.querySelector('.profile-greeting').textContent = greeting;
+});
+```
+
+### Sign-out button
+
+```js
+document.querySelector('.sign-out-button').addEventListener('click', function() {
+  Fliplet.Auth.signOut().then(function() {
+    location.reload();
+  });
+});
+```
+
+### Refresh the UI when auth state changes
+
+Useful when the user signs in or out via a different mechanism (e.g. a Fliplet Login widget on another screen).
+
+```js
+Fliplet.Auth.onChange(function(user) {
+  if (user) {
+    document.body.classList.add('signed-in');
+  } else {
+    document.body.classList.remove('signed-in');
+  }
+});
+```
+
+### Make an authenticated API request
+
+```js
+Fliplet.Auth.getToken().then(function(token) {
+  if (!token) {
+    throw new Error('Not signed in');
+  }
+
+  return Fliplet.API.request({
+    url: 'v1/user',
+    headers: { 'Auth-Token': token }
+  });
+}).then(function(response) {
+  console.log(response.user);
+});
+```
+
+---
+
+## What `Fliplet.Auth` does NOT do
+
+- **It does not create new Fliplet user accounts from inside an app.** Only Studio's sign-up page can create Fliplet accounts. An app's sign-in popup can authenticate existing Fliplet users (including via SSO) — but it will not create a new account. Users who don't yet have a Fliplet account see an error message asking them to sign up at Fliplet Studio first.
+- **It does not manage app-specific user data.** Use a Data Source with the [data source login component](components/login.md) or your own custom logic for that. `Fliplet.Auth` authenticates Fliplet users, not app-specific records.
+
+---
+
+[Back to API documentation](../API-Documentation.md)
+{: .buttons}

--- a/docs/API/fliplet-auth.md
+++ b/docs/API/fliplet-auth.md
@@ -1,58 +1,59 @@
+---
+description: Sign users into your Fliplet app with one line of code — email/password or SSO (Google, Microsoft, Apple).
+---
+
 # Auth JS APIs
 
-The Fliplet Auth JS APIs let you sign users into your Fliplet app with one line of code. It opens the unified sign-in popup (served by the Fliplet API) and handles the round-trip for you — including email/password and SSO (Google, Microsoft, Apple).
+The Fliplet Auth JS APIs sign users into your Fliplet app with their existing Fliplet account. One call opens a popup, handles the authentication round-trip, and resolves with the signed-in user. Email/password and SSO (Google, Microsoft, Apple) are supported out of the box.
 
-Use these APIs to:
+Use these APIs to authenticate Fliplet users, read the signed-in user in your app code, sign users out, and get the auth token for custom API requests.
 
-- Sign users into your app with their Fliplet account
-- Read the currently signed-in user
-- Sign users out
-- Get the auth token for custom API calls
-- React to sign-in / sign-out events
+## Before you start
 
-Add the `fliplet-auth` package to your app's dependencies to enable these APIs.
+Add the `fliplet-auth` package to your app's dependencies. This exposes `Fliplet.Auth.*` at runtime.
 
----
+<p class="warning"><code>Fliplet.Auth</code> authenticates <strong>existing Fliplet user accounts</strong>. It does not create new accounts from inside an app — only Fliplet Studio's sign-up page can do that. A user who tries to sign in with an SSO provider (Google, Microsoft, Apple) that isn't linked to any Fliplet account sees an error asking them to sign up at Fliplet Studio first. Direct users to Fliplet Studio to create their account, then back to your app to sign in.</p>
+
+`Fliplet.Auth` is the high-level API for signing users in and out — prefer it for app code. It is distinct from two other APIs that share related concepts:
+
+- **`Fliplet.User`** — low-level primitives (`getAuthToken`, `setAuthToken`, `getCachedSession`). `Fliplet.Auth` uses these internally; you rarely need to call them directly.
+- **Data source login component** — an app-level authentication system that uses a data source as the user table. It's a separate system from `Fliplet.Auth` and is appropriate when you want users stored in your app's own data source rather than in Fliplet's user database. See [data source login](components/login.md) for that.
 
 ## Methods
 
 ### Sign a user in
 
-Opens the unified sign-in popup. Resolves with `{ user, token }` when the user successfully signs in.
+`Fliplet.Auth.signIn()` opens the unified sign-in popup and resolves with `{ user, token }` when the user successfully signs in.
 
 ```js
 Fliplet.Auth.signIn().then(function(result) {
+  // result.user:  { id, email, firstName, lastName, userRoleId }
+  // result.token: auth token string, e.g. "eu--55a54008...-203-8965"
   console.log('Signed in as', result.user.email);
-  console.log('Auth token:', result.token);
-});
-```
-
-Pre-fill the email field in the sign-in form:
-
-```js
-Fliplet.Auth.signIn({ email: 'user@example.com' });
-```
-
-The promise rejects with an `Error` when:
-
-- The popup is blocked by the browser
-- The user closes the popup without completing sign-in
-- The sign-in times out (10 minutes)
-- The API returns an error (invalid credentials, 2FA flow cannot complete, etc.)
-
-```js
-Fliplet.Auth.signIn().then(function(result) {
-  // user signed in
 }).catch(function(err) {
+  // surface the error to the user and let them retry
   console.error(err.message);
 });
 ```
 
----
+Pre-fill the email field in the sign-in form by passing `options.email`:
+
+```js
+Fliplet.Auth.signIn({ email: 'alice@acme.com' });
+```
+
+The promise **rejects with an `Error`** when:
+
+- The popup is blocked by the browser → `Error('Sign-in popup was blocked...')`
+- The user closes the popup without completing sign-in → `Error('Sign-in was cancelled.')`
+- Sign-in times out after 10 minutes → `Error('Sign-in timed out. Please try again.')`
+- The API returns a sign-in error → `Error(<message from API>)`
+
+Always handle rejection in your app code — the examples on this page consistently do so.
 
 ### Get the currently signed-in user
 
-Resolves to the signed-in user, or `null` when no user is signed in.
+`Fliplet.Auth.currentUser()` resolves to the signed-in user, or `null` when no user is signed in.
 
 ```js
 Fliplet.Auth.currentUser().then(function(user) {
@@ -61,86 +62,106 @@ Fliplet.Auth.currentUser().then(function(user) {
     return;
   }
 
-  // contains id, email, userRoleId, region
-  console.log(user);
+  // user shape: { id, email, userRoleId }
+  console.log(user.email);
 });
 ```
 
----
+The user object returned by `currentUser()` contains a subset of the fields returned by `signIn()` — specifically the fields that persist locally between sessions: `id`, `email`, `userRoleId`. To access `firstName` and `lastName`, either store them yourself after `signIn()` resolves, or query `v1/user` with `Fliplet.Auth.getToken()`.
 
 ### Check whether a user is signed in
 
-A convenience helper that resolves to a boolean.
+`Fliplet.Auth.isSignedIn()` resolves to `true` or `false` — a convenience helper on top of `currentUser()`.
 
 ```js
 Fliplet.Auth.isSignedIn().then(function(isSignedIn) {
   if (isSignedIn) {
-    // user is signed in
+    // show authenticated UI
   }
 });
 ```
 
----
-
 ### Get the user's auth token
 
-Resolves to the signed-in user's auth token, or `null` when no user is signed in. Use it to authenticate custom API calls as the signed-in user.
+`Fliplet.Auth.getToken()` resolves to the signed-in user's auth token, or `null` when no user is signed in. Use it to authenticate custom API calls as the signed-in user.
 
 ```js
 Fliplet.Auth.getToken().then(function(token) {
-  return fetch(url, {
+  if (!token) {
+    throw new Error('Not signed in');
+  }
+
+  return fetch('https://api.example.com/my-endpoint', {
     headers: { 'Auth-Token': token }
   });
 });
 ```
 
----
-
-### Sign the user out
-
-Clears locally stored credentials and invalidates the server-side session.
+Pair with `Fliplet.API.request()` for calls to the Fliplet API:
 
 ```js
-Fliplet.Auth.signOut().then(function() {
-  // user is signed out
+Fliplet.Auth.getToken().then(function(token) {
+  return Fliplet.API.request({
+    url: 'v1/user',
+    headers: { 'Auth-Token': token }
+  });
+}).then(function(response) {
+  console.log(response.user);
 });
 ```
 
----
+### Sign the user out
+
+`Fliplet.Auth.signOut()` clears locally stored credentials and invalidates the server-side session.
+
+```js
+Fliplet.Auth.signOut().then(function() {
+  // user is signed out; currentUser() now resolves to null
+});
+```
+
+If the server-side logout request fails (for example, the device is offline), local credentials are still cleared so the user is effectively signed out.
 
 ### Listen for sign-in / sign-out events
 
-Subscribe to auth state changes. The callback fires with the new user after a successful sign-in, or with `null` after sign-out completes.
+`Fliplet.Auth.onChange(callback)` subscribes to auth state changes. The callback fires with the new user after a successful sign-in, or with `null` after sign-out completes. Returns an unsubscribe function.
 
 ```js
 var unsubscribe = Fliplet.Auth.onChange(function(user) {
   if (user) {
-    // user just signed in
+    // user just signed in — refresh the UI as this user
   } else {
-    // user just signed out
+    // user just signed out — reset to logged-out state
   }
 });
 
-// Stop listening when you no longer need to
+// Stop listening when no longer needed
 unsubscribe();
 ```
 
----
+Useful when the user signs in or out via a different mechanism — for example, a Fliplet Login component on another screen.
 
 ## Examples
 
 ### Gate a screen behind sign-in
 
-Prompt the user to sign in if they're not already signed in, then continue with the rest of the screen.
+Prompt the user to sign in if they're not already signed in, then render the screen.
 
 ```js
 Fliplet.Auth.currentUser().then(function(user) {
-  if (user) return user;
+  if (user) {
+    return user;
+  }
+
   return Fliplet.Auth.signIn().then(function(result) {
     return result.user;
   });
 }).then(function(user) {
   // render the screen as this user
+  document.querySelector('.greeting').textContent = 'Welcome, ' + user.email;
+}).catch(function(err) {
+  // user cancelled sign-in or it failed
+  console.error(err.message);
 });
 ```
 
@@ -149,8 +170,8 @@ Fliplet.Auth.currentUser().then(function(user) {
 ```js
 Fliplet.Auth.currentUser().then(function(user) {
   var greeting = user
-    ? 'Welcome, ' + user.email
-    : 'Sign in to continue';
+    ? 'Signed in as ' + user.email
+    : 'Not signed in';
 
   document.querySelector('.profile-greeting').textContent = greeting;
 });
@@ -167,8 +188,6 @@ document.querySelector('.sign-out-button').addEventListener('click', function() 
 ```
 
 ### Refresh the UI when auth state changes
-
-Useful when the user signs in or out via a different mechanism (e.g. a Fliplet Login widget on another screen).
 
 ```js
 Fliplet.Auth.onChange(function(user) {
@@ -189,22 +208,15 @@ Fliplet.Auth.getToken().then(function(token) {
   }
 
   return Fliplet.API.request({
-    url: 'v1/user',
+    url: 'v1/organizations',
     headers: { 'Auth-Token': token }
   });
 }).then(function(response) {
-  console.log(response.user);
+  console.log('Organizations:', response.organizations);
+}).catch(function(err) {
+  console.error(err);
 });
 ```
-
----
-
-## What `Fliplet.Auth` does NOT do
-
-- **It does not create new Fliplet user accounts from inside an app.** Only Studio's sign-up page can create Fliplet accounts. An app's sign-in popup can authenticate existing Fliplet users (including via SSO) — but it will not create a new account. Users who don't yet have a Fliplet account see an error message asking them to sign up at Fliplet Studio first.
-- **It does not manage app-specific user data.** Use a Data Source with the [data source login component](components/login.md) or your own custom logic for that. `Fliplet.Auth` authenticates Fliplet users, not app-specific records.
-
----
 
 [Back to API documentation](../API-Documentation.md)
 {: .buttons}

--- a/docs/API/fliplet-auth.md
+++ b/docs/API/fliplet-auth.md
@@ -62,12 +62,12 @@ Fliplet.Auth.currentUser().then(function(user) {
     return;
   }
 
-  // user shape: { id, email, userRoleId }
+  // user shape: { id, email, userRoleId, region, legacy }
   console.log(user.email);
 });
 ```
 
-The user object returned by `currentUser()` contains a subset of the fields returned by `signIn()` — specifically the fields that persist locally between sessions: `id`, `email`, `userRoleId`. To access `firstName` and `lastName`, either store them yourself after `signIn()` resolves, or query `v1/user` with `Fliplet.Auth.getToken()`.
+The user object returned by `currentUser()` contains the fields that persist locally between sessions: `id`, `email`, `userRoleId`, `region`, and `legacy`. It does **not** include `firstName` / `lastName` (which `signIn()` returns) — to access those, either store them yourself after `signIn()` resolves, or query `v1/user` with `Fliplet.Auth.getToken()`.
 
 ### Check whether a user is signed in
 
@@ -83,7 +83,9 @@ Fliplet.Auth.isSignedIn().then(function(isSignedIn) {
 
 ### Get the user's auth token
 
-`Fliplet.Auth.getToken()` resolves to the signed-in user's auth token, or `null` when no user is signed in. Use it to authenticate custom API calls as the signed-in user.
+`Fliplet.Auth.getToken()` resolves to the signed-in user's auth token, or `null` when no user is signed in. Use it to authenticate calls to the Fliplet API as the signed-in user.
+
+<p class="warning"><strong>Only send the auth token to the Fliplet API.</strong> The token grants full access to this user's Fliplet account — treat it like a password. Never put it in the URL, log it, or send it to a third-party / non-Fliplet endpoint, as that hands the user's account to whoever receives it. To call your own backend, send a short-lived token your backend issues, not the Fliplet auth token.</p>
 
 ```js
 Fliplet.Auth.getToken().then(function(token) {
@@ -91,16 +93,6 @@ Fliplet.Auth.getToken().then(function(token) {
     throw new Error('Not signed in');
   }
 
-  return fetch('https://api.example.com/my-endpoint', {
-    headers: { 'Auth-Token': token }
-  });
-});
-```
-
-Pair with `Fliplet.API.request()` for calls to the Fliplet API:
-
-```js
-Fliplet.Auth.getToken().then(function(token) {
   return Fliplet.API.request({
     url: 'v1/user',
     headers: { 'Auth-Token': token }
@@ -109,6 +101,8 @@ Fliplet.Auth.getToken().then(function(token) {
   console.log(response.user);
 });
 ```
+
+`Fliplet.API.request()` is the recommended way to call the Fliplet API — it targets the correct API host for you and keeps the token on the Fliplet origin.
 
 ### Sign the user out
 
@@ -139,7 +133,7 @@ var unsubscribe = Fliplet.Auth.onChange(function(user) {
 unsubscribe();
 ```
 
-Useful when the user signs in or out via a different mechanism — for example, a Fliplet Login component on another screen.
+<p class="quote"><code>onChange</code> fires only for sign-ins and sign-outs performed through <code>Fliplet.Auth.signIn()</code> and <code>Fliplet.Auth.signOut()</code>. It does not currently fire for auth changes made by other mechanisms (for example a Fliplet Login component on another screen), since those don't route through this API.</p>
 
 ## Examples
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -203,6 +203,7 @@
                   <li><a href="/API-Documentation.html">Overview</a></li>
                   <li><p>Libraries</p></li>
                   <li><a href="/API/core/overview.html">Core</a></a></li>
+                  <li><a href="/API/fliplet-auth.html">Auth <span class="label">NEW</span></a></li>
                   <li><a href="/API/fliplet-communicate.html">Communicate</a></li>
                   <li><a href="/API/fliplet-datasources.html">Data Sources</a></li>
                   <li><a href="/API/fliplet-encryption.html">Encryption</a></li>

--- a/fliplet-login.js
+++ b/fliplet-login.js
@@ -1,6 +1,6 @@
 require('colors');
 
-const _ = require('lodash');
+const url = require('url');
 
 const auth = require('./lib/auth');
 const config = require('./lib/config');
@@ -20,7 +20,16 @@ ${'Press Ctrl+C to exit.'.blue}
 
 const port = 9001;
 const baseUrl = `http://localhost:${port}`;
-const redirectUrl = `${config.api_url}v1/auth/third-party?redirect=${encodeURIComponent(`${baseUrl}/callback`)}&responseType=code&source=CLI&title=Sign%20in%20to%20Authorize%20the%20Fliplet%20CLI`;
+const callbackUrl = `${baseUrl}/callback`;
+
+// New unified sign-in URL — replaces the legacy /v1/auth/third-party flow.
+// The page validates the callback URL against an allow-list (which already
+// includes http://localhost:9001/callback) and on success navigates the
+// browser to <callback>?token=XXX&user=<base64-json>.
+const redirectUrl = `${config.api_url}v1/auth/login`
+  + `?return=callback`
+  + `&callback=${encodeURIComponent(callbackUrl)}`
+  + `&source=CLI`;
 
 require('http').createServer(function(req, res) {
   if (req.url.match(/login/)) {
@@ -38,18 +47,30 @@ require('http').createServer(function(req, res) {
   }
 
   if (req.url.match(/callback/)) {
-    const authToken = _.last(req.url.split('auth_token='));
+    // Parse the token (and optional user payload) from the callback URL.
+    // The unified contract delivers them as `?token=...&user=<base64>`.
+    const parsed = url.parse(req.url, true);
+    const authToken = parsed.query.token;
+
+    if (!authToken) {
+      console.error('No auth token received from the sign-in flow.');
+      res.writeHead(400);
+      res.end('Missing token');
+      return process.exit(1);
+    }
 
     auth.setUserForToken(authToken).then(function(user) {
       organizations.getOrganizationsList().then(function onGetOrganizations(organizations) {
         if (!organizations.length) {
-          return console.error('Your organization has not been found.');
+          console.error('Your organization has not been found.');
+          res.writeHead(400);
+          res.end('No organizations available for this account.');
+          return process.exit(1);
         }
 
-        if (organizations.length > 1) {
-          return console.error('You belong to multiple organizations.');
-        }
-
+        // For users belonging to multiple organizations, default to the
+        // first one. They can switch later via `fliplet organization <id>`
+        // (use `fliplet list-organizations` to see all available IDs).
         const userOrganization = organizations[0];
 
         config.set('organization', userOrganization);
@@ -57,18 +78,29 @@ require('http').createServer(function(req, res) {
         console.log('----------------------------------------------------------\r\n');
         console.log(`You have logged in successfully. Welcome back, ${user.fullName.yellow.underline}!`);
         console.log(`Your organization has been set to ${userOrganization.name.green.underline} (#${userOrganization.id}). Your account email is ${user.email.yellow.underline}.`);
-        console.log(`You can now develop and publish components via the ${'fliplet run'.bgBlack.red} command!
-`);
+
+        if (organizations.length > 1) {
+          console.log(`\n${'Note'.yellow}: you belong to ${organizations.length} organizations. To switch, run ${'fliplet list-organizations'.bgBlack.red} to see all of them and ${'fliplet organization <id>'.bgBlack.red} to change.`);
+        }
+
+        console.log(`\nYou can now develop and publish components via the ${'fliplet run'.bgBlack.red} command!\n`);
 
         res.writeHead(302, {
           'Location': `${baseUrl}/success?${Date.now()}`
         });
 
         return res.end();
+      }).catch(function(err) {
+        console.error('Failed to fetch organizations:', err);
+        res.writeHead(500);
+        res.end('Failed to fetch organizations');
+        return process.exit(1);
       });
     }).catch(function(err) {
       console.error(err);
-      process.exit();
+      res.writeHead(500);
+      res.end('Authentication failed');
+      return process.exit(1);
     });
   }
 }).listen(9001);

--- a/fliplet-login.js
+++ b/fliplet-login.js
@@ -32,7 +32,16 @@ const redirectUrl = `${config.api_url}v1/auth/login`
   + `&source=CLI`;
 
 require('http').createServer(function(req, res) {
-  if (req.url.match(/login/)) {
+  // Route on the parsed pathname, NOT a loose `req.url.match(/.../)`. The
+  // unified callback carries the signed-in user's data in the query string
+  // (`?token=...&user=<url-encoded-json>`), so a substring match against the
+  // whole URL would misroute any user whose email or name contains "login"
+  // or "success" (e.g. john.login@acme.com, anyone named "Success") into the
+  // wrong branch — breaking their sign-in. Pathname matching is exact.
+  const parsed = url.parse(req.url, true);
+  const pathname = parsed.pathname;
+
+  if (pathname === '/login') {
     res.writeHead(302, {
       'Location': redirectUrl
     });
@@ -40,16 +49,15 @@ require('http').createServer(function(req, res) {
     return res.end();
   }
 
-  if (req.url.match(/success/)) {
+  if (pathname === '/success') {
     res.end(`<html><body style="font-size:20px;font-family:sans-serif"><p><strong>You have been logged in successfully to your Fliplet account.</strong></p><p>You may now <a href="javascript:window.close()">close</a> this window now and return to the terminal to continue the process.</p><script>setTimeout(function () { window.close(); }, ${config.env === 'local' ? 0 : 5000});</script></body></html>`);
 
     return process.exit();
   }
 
-  if (req.url.match(/callback/)) {
-    // Parse the token (and optional user payload) from the callback URL.
-    // The unified contract delivers them as `?token=...&user=<base64>`.
-    const parsed = url.parse(req.url, true);
+  if (pathname === '/callback') {
+    // Token (and optional user payload) come from the callback query string.
+    // The unified contract delivers them as `?token=...&user=<url-encoded-json>`.
     const authToken = parsed.query.token;
 
     if (!authToken) {

--- a/fliplet-login.js
+++ b/fliplet-login.js
@@ -25,11 +25,14 @@ const callbackUrl = `${baseUrl}/callback`;
 // New unified sign-in URL — replaces the legacy /v1/auth/third-party flow.
 // The page validates the callback URL against an allow-list (which already
 // includes http://localhost:9001/callback) and on success navigates the
-// browser to <callback>?token=XXX&user=<base64-json>.
+// browser to <callback>?token=XXX&user=<url-encoded-json>.
+//
+// No `&source=CLI`: the unified login page derives the session source from
+// `isEmbedded` (views/login.pug) and does not read `?source=`, so passing it
+// here would be a dead param that never tags the session.
 const redirectUrl = `${config.api_url}v1/auth/login`
   + `?return=callback`
-  + `&callback=${encodeURIComponent(callbackUrl)}`
-  + `&source=CLI`;
+  + `&callback=${encodeURIComponent(callbackUrl)}`;
 
 require('http').createServer(function(req, res) {
   // Route on the parsed pathname, NOT a loose `req.url.match(/.../)`. The
@@ -111,6 +114,6 @@ require('http').createServer(function(req, res) {
       return process.exit(1);
     });
   }
-}).listen(9001);
+}).listen(port);
 
 require('openurl').open(`${baseUrl}/login?${Date.now()}`);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -28,7 +28,8 @@ function login(options) {
 function setUserForToken(authToken) {
   return new Promise(function(resolve, reject) {
     request({
-      url: config.api_url + 'v1/user?auth_token=' + authToken
+      url: config.api_url + 'v1/user',
+      headers: { 'Auth-Token': authToken }
     }, function(error, response, body) {
       if (error) {
         return reject({ error, response, body });
@@ -64,7 +65,8 @@ function isAdmin() {
   return new Promise(function(resolve, reject) {
     request({
       method: 'GET',
-      url: `${config.api_url}v1/user?auth_token=${auth_token}`
+      url: `${config.api_url}v1/user`,
+      headers: { 'Auth-Token': auth_token }
     }, function(error, response, body) {
       if (error) {
         reject(error);

--- a/lib/organizations.js
+++ b/lib/organizations.js
@@ -2,11 +2,15 @@ const request = require('request');
 const config = require('./config');
 
 var organizationsList;
-var user = config.data.user || {};
-var auth_token = user.auth_token;
 
 function getOrganizationsListFromServer() {
   return new Promise(function(resolve, reject) {
+    // Read the auth token lazily — sign-in may have happened after
+    // this module was loaded, in which case the cached user object
+    // from module-init time would be stale.
+    var user = config.data.user || {};
+    var auth_token = user.auth_token;
+
     if (!auth_token) {
       return reject('You must login first with: fliplet login');
     }

--- a/lib/organizations.js
+++ b/lib/organizations.js
@@ -19,7 +19,10 @@ function getOrganizationsListFromServer() {
       return resolve(organizationsList);
     }
 
-    request(config.api_url + 'v1/organizations?auth_token=' + auth_token, function(error, response, body) {
+    request({
+      url: config.api_url + 'v1/organizations',
+      headers: { 'Auth-Token': auth_token }
+    }, function(error, response, body) {
       if (error) {
         return reject(error);
       }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -62,7 +62,8 @@ function publish(user, opts = {}) {
       const options = {
         method: 'POST',
         json: true,
-        url: config.api_url + 'v1/widgets?auth_token=' + auth_token,
+        url: config.api_url + 'v1/widgets',
+        headers: { 'Auth-Token': auth_token },
         formData: formData,
         timeout: 1000 * 60 * 5 // 5 minutes
       };

--- a/lib/template.js
+++ b/lib/template.js
@@ -4,17 +4,19 @@ const request = require('request');
 const config = require('./config');
 
 function compile(options) {
-  let url = config.api_url + 'v1/widgets/compile';
+  const url = config.api_url + 'v1/widgets/compile';
   const user = config.get('user');
+  const headers = {};
 
   if (user && user.authToken) {
-    url += `?auth_token=${user.authToken}`;
+    headers['Auth-Token'] = user.authToken;
   }
 
   return new Promise(function(resolve, reject) {
     request({
       method: 'POST',
       url,
+      headers,
       gzip: true,
       json: options
     }, function(error, response, body) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-cli",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

Migrates the Fliplet CLI login to the unified auth flow and adds the
`Fliplet.Auth` JS API reference to the developer docs.

### CLI login (`fliplet-login.js`, `lib/organizations.js`)
- Replace the removed `/v1/auth/third-party` endpoint with the unified
  `/v1/auth/login?return=callback&callback=http://localhost:9001/callback` contract
- Parse `?token=<token>` (new contract) instead of `?auth_token=<token>`, via `url.parse`
- Route the local callback server on the **parsed pathname** (`/login`, `/success`,
  `/callback`) instead of a loose `req.url.match(/.../)`. The unified callback now
  carries the user's data (`&user=<url-encoded-json>`), so a substring match would
  misroute any user whose email or name contains "login"/"success" — breaking their
  sign-in. Pathname matching is exact.
- Multi-org users: pick the first org by default instead of hard-failing, and print
  a note on how to switch (`fliplet organization <id>`)
- All error paths write an HTTP response + `process.exit(1)` (prevents browser
  retries that triggered duplicate errors)
- Read `auth_token` lazily in `organizations.js` (the module-load-time read was stale
  on first login, since sign-in happens after module init)

### Docs (`docs/API/fliplet-auth.md` + sidebar)
- New **Fliplet.Auth JS API** reference (`signIn`, `currentUser`, `isSignedIn`,
  `getToken`, `signOut`, `onChange`), verified against the shipped
  `public/assets/fliplet-auth/1.0/auth.js` on fliplet-api master
- Security: the `getToken()` example sends the auth token to the Fliplet API only,
  with a warning to never send it to third-party endpoints (treat it like a password)
- `onChange` documented as firing only for `Fliplet.Auth.signIn()`/`signOut()`
- `currentUser()` shape includes `region` and `legacy`

## Test plan
- [ ] Run `node fliplet-login.js` (or `fliplet login` if linked) — browser opens to the unified sign-in page
- [ ] Sign in with email/password — CLI prints success and org info
- [ ] Sign in with SSO (Google/Microsoft) — same flow works
- [ ] Multi-org user — first org picked, switch note printed
- [ ] **User whose email/name contains "login" or "success"** (e.g. `john.login@acme.com`) — sign-in completes (regression test for the routing fix)
- [ ] Close the browser without completing — CLI exits cleanly
- [ ] Docs render correctly on the developer-docs site (callouts, code blocks)

## Note on sequencing
The `Fliplet.Auth` "signed into your app" experience depends on fliplet-api PR #8199
(restores the `flipletLogin` passport for embedded/return-mode logins). Publish these
docs after #8199 lands so the cross-widget "signed in" behaviour they describe is true
end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
