### PR TITLE
fix(docs): restore homepage by setting permalink: / on README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ type: tutorial
 tags: [readme]
 v3_relevant: true
 deprecated: false
+permalink: /
 ---
 # Fliplet Developers documentation
 


### PR DESCRIPTION
## Problem

`https://developers.fliplet.com/` returns **HTTP 404**. Has been broken since the Cloudflare Pages migration on 2026-04-22 — GitHub Pages had a special case mapping `README.md` → `index.html`, vanilla Jekyll on CF Pages does not.

Local Jekyll build before this change:
```
$ bundle exec jekyll build && ls _site/{index,README}.html
ls: _site/index.html: No such file or directory
-rw-r--r--  _site/README.html
```

## Fix

One line: add `permalink: /` to `docs/README.md` frontmatter. Jekyll then renders the homepage to `_site/index.html`.

Local Jekyll build after this change:
```
$ bundle exec jekyll build && ls _site/{index,README}.html
-rw-r--r--  _site/index.html
ls: _site/README.html: No such file or directory
```

## Verification

- [ ] CF Pages preview: `https://<preview-url>/` returns 200 with rendered homepage HTML.
- [ ] After merge: `https://developers.fliplet.com/` returns 200.
- [ ] `/.well-known/llms.txt` skill entry for the marker (`readme`) keeps URL `https://developers.fliplet.com/` (already correct in build script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)