### PR TITLE
chore(docs): nested node_modules exclusion + dedupe _headers

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,22 +1,25 @@
+# CF Pages applies all matching rule blocks (specific path AND wildcard
+# combine). To avoid duplicating Access-Control-Allow-Origin and
+# Cache-Control on every response, common headers live in the wildcard
+# block; specific blocks below it carry only Content-Type overrides.
+
+# Content-Type overrides for specific paths
 /.well-known/api-catalog
   Content-Type: application/linkset+json
-  Access-Control-Allow-Origin: *
-  Cache-Control: public, max-age=3600
 
 /.well-known/llms.txt
   Content-Type: text/plain; charset=utf-8
-  Access-Control-Allow-Origin: *
-  Cache-Control: public, max-age=3600
 
 /.well-known/llms-full.txt
   Content-Type: text/plain; charset=utf-8
-  Access-Control-Allow-Origin: *
-  Cache-Control: public, max-age=3600
 
+# Common headers for everything under /.well-known/
 /.well-known/*
   Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=3600
 
+# Markdown sibling files served with text/markdown + CORS so AI clients
+# can fetch raw source from the same URL paths as the generated HTML.
 /*.md
   Content-Type: text/markdown; charset=utf-8
   Access-Control-Allow-Origin: *

--- a/docs/bin/build-agent-indexes.mjs
+++ b/docs/bin/build-agent-indexes.mjs
@@ -86,7 +86,12 @@ function shouldExclude(relPath) {
   if (EXCLUDED_FILES.has(relPath)) return true;
   if (relPath.endsWith('.deprecated.md')) return true;
   for (const d of EXCLUDED_DIRS) {
-    if (relPath === d || relPath.startsWith(d + '/')) return true;
+    // Match the dir at the root OR nested at any depth (e.g. mcp-worker/node_modules/...).
+    // The nested check is what stops mcp-worker/node_modules/**/README.md from leaking
+    // into the index when someone runs the script after `npm install` in mcp-worker/.
+    if (relPath === d || relPath.startsWith(d + '/') || relPath.includes('/' + d + '/')) {
+      return true;
+    }
   }
   return false;
 }

--- a/docs/bin/copy-md-siblings.mjs
+++ b/docs/bin/copy-md-siblings.mjs
@@ -55,7 +55,10 @@ function shouldExclude(relPath) {
   if (EXCLUDED_FILES.has(relPath)) return true;
   if (relPath.endsWith('.deprecated.md')) return true;
   for (const d of EXCLUDED_DIRS) {
-    if (relPath === d || relPath.startsWith(d + '/')) return true;
+    // Match the dir at the root OR nested at any depth (e.g. mcp-worker/node_modules/...).
+    if (relPath === d || relPath.startsWith(d + '/') || relPath.includes('/' + d + '/')) {
+      return true;
+    }
   }
   return false;
 }

--- a/docs/bin/migrate-frontmatter.mjs
+++ b/docs/bin/migrate-frontmatter.mjs
@@ -77,7 +77,10 @@ function shouldExclude(relPath) {
   if (EXCLUDED_FILES.has(relPath)) return true;
   if (relPath.endsWith('.deprecated.md')) return true;
   for (const d of EXCLUDED_DIRS) {
-    if (relPath === d || relPath.startsWith(d + '/')) return true;
+    // Match the dir at the root OR nested at any depth (e.g. mcp-worker/node_modules/...).
+    if (relPath === d || relPath.startsWith(d + '/') || relPath.includes('/' + d + '/')) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
Two small infra-polish items uncovered during the post-merge verification of #243 and #244.

## 1. Build scripts: nested directory exclusion

Before, `EXCLUDED_DIRS` in \`bin/build-agent-indexes.mjs\`, \`copy-md-siblings.mjs\`, and \`migrate-frontmatter.mjs\` only matched a directory at the **root** of the docs tree. A relative path like \`mcp-worker/node_modules/foo/README.md\` slipped past \`relPath.startsWith('node_modules/')\` and got indexed.

**Impact:** local-only. CF Pages is unaffected because it never installs deps in \`docs/mcp-worker/\`. But anyone running \`node bin/build-agent-indexes.mjs\` after \`npm install\` in \`docs/mcp-worker/\` saw 523 entries in \`.well-known/agent-skills/index.json\` instead of the expected 174.

**Fix:** also match nested occurrences via \`relPath.includes('/' + d + '/')\`. Verified locally: count drops from 523 → 175 (174 docs + the still-merged Phase 3 marker).

## 2. \`_headers\`: dedupe CORS / Cache-Control

CF Pages combines matching rule blocks (specific path + wildcard) into one response. Both the specific paths under \`/.well-known/\` AND the \`/.well-known/*\` wildcard set \`Access-Control-Allow-Origin\` and \`Cache-Control\`, so production saw:

\`\`\`
access-control-allow-origin: *, *
cache-control: public, max-age=3600, public, max-age=3600
\`\`\`

Cosmetic — browsers tolerate it — but noisy in headers panels and a sign of config drift. **Fix:** specific blocks under \`/.well-known/\` now carry only \`Content-Type\` overrides; the wildcard \`/.well-known/*\` is the single source of CORS + Cache-Control. \`/*.md\` keeps all three (no wildcard above it).

## Test plan

- [x] All 38 \`bin/__tests__/*.test.mjs\` tests still pass
- [x] Local run of \`node bin/build-agent-indexes.mjs\` returns 175 entries (was 523 with mcp-worker/node_modules populated)
- [ ] After merge, production \`/.well-known/llms.txt\` headers no longer doubled (verify with \`curl -sI\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)