### PR TITLE
docs: cluster-shape agent-skills + publish MCP server card

### DIFF
--- a/docs/.well-known/agent-skills/fliplet-app-actions/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-app-actions/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: fliplet-app-actions
+description: Build server-side automations that run on a schedule or in response to events. Covers App Actions v1, v2, and v3 APIs.
+---
+
+# Fliplet App Actions (server-side automations)
+
+Build server-side automations that run on a schedule or in response to events. Covers App Actions v1, v2, and v3 APIs.
+
+## Documentation
+
+- [App Actions V2 (deprecated)](https://developers.fliplet.com/API/core/app-actions-v2.html): Deprecated App Actions V2 — configure a pipeline of functions that runs on-device or in the cloud, ad hoc or on a schedule. Migrate to V3.
+- [App Actions V3](https://developers.fliplet.com/API/core/app-actions-v3.html): Write and run JavaScript code directly on the server or client to perform automations, scheduled tasks and on-demand operations.
+- [App Actions V1 (deprecated)](https://developers.fliplet.com/API/core/app-actions.html): Deprecated App Actions V1 — run app screens automatically on a schedule or on demand in the cloud. Migrate to V3.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-app-build-and-publish/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-app-build-and-publish/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fliplet-app-build-and-publish
+description: Publish Fliplet apps to iOS, Android, and the web: bundle size, certificates, automated app builds, platform-specific gotchas.
+---
+
+# Fliplet app build and publish
+
+Publish Fliplet apps to iOS, Android, and the web: bundle size, certificates, automated app builds, platform-specific gotchas.
+
+## Documentation
+
+- [Manually creating a P12 certificate](https://developers.fliplet.com/aab/create-p12-certificate.html): Generate a P12 signing key from an Apple Enterprise account to supply to Fliplet's Automated App Build system.
+- [Advanced features for the Android platform](https://developers.fliplet.com/Platform-Android.html): How to detect Android at runtime and enable the hardware back button inside a Fliplet app.
+- [Advanced features for the iOS platform](https://developers.fliplet.com/Platform-iOS.html): How to detect iOS at runtime and supply a manual P12 certificate when using Fliplet's Automated App Build with an Apple Enterprise account.
+- [Publishing components, themes and menus](https://developers.fliplet.com/Publishing.html): How to publish Fliplet components, themes, and menus to the Fliplet platform using the CLI's publish command.
+- [Reduce your app bundle size](https://developers.fliplet.com/Reduce-app-bundle-size.html): Exclude assets from your Fliplet app bundle by content type, file extension, or media file ID to shrink it for App Store and Google Play submission.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-components-framework/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-components-framework/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: fliplet-components-framework
+description: Build custom components (widgets) that ship inside Fliplet apps: component definitions, lifecycle, events, dependencies, providers, custom templates, testing.
+---
+
+# Fliplet components framework
+
+Build custom components (widgets) that ship inside Fliplet apps: component definitions, lifecycle, events, dependencies, providers, custom templates, testing.
+
+## Documentation
+
+- [Building Fliplet components](https://developers.fliplet.com/Building-components.html): How to scaffold, run, and develop a Fliplet component locally using the CLI, including the generated file layout and the local dev server.
+- [Building Fliplet app action functions](https://developers.fliplet.com/Building-functions.html): How to scaffold and develop an app action function with the CLI, declare its dependencies, and configure it via widget.json.
+- [Cloning widgets, components, and themes from the CLI](https://developers.fliplet.com/Cloning-widgets.html): How to use the fliplet clone and fliplet list CLI commands to download the source of a published component, menu, or theme to your machine.
+- [Component events](https://developers.fliplet.com/Component-events.html): Listen for component lifecycle events (adding, added, removed, moved, render) emitted while users edit a Fliplet screen, via Fliplet.Hooks.on('componentEvent').
+- [Output of components](https://developers.fliplet.com/components/Build-output.html): Render Fliplet component output from build.html via Handlebars; read per-instance settings with Fliplet.Widget.instance and support dynamic-container context.
+- [The component definition file](https://developers.fliplet.com/components/Definition.html): Define a Fliplet component in widget.json: name, package, version, icon, tags, html_tag, plus interface and build entries for dependencies and assets.
+- [Components interfaces](https://developers.fliplet.com/components/Interface.html): Build a Fliplet component's settings UI in interface.html with Handlebars; persist values via Fliplet.Widget.save and rehydrate with Fliplet.Widget.getData.
+- [Using providers](https://developers.fliplet.com/components/Using-Providers.html): Components can display providers to get specific data from the system or need a particular piece of functionality to be added.
+- [Context targeting](https://developers.fliplet.com/Context-targeting.html): Target devices in Fliplet apps via Modernizr classes and JS flags for iOS, Android, Windows, web, native, mobile/tablet/desktop, notch, and Studio edit mode.
+- [Custom Headers](https://developers.fliplet.com/Custom-Headers.html): Configure custom HTTP response headers (CSP, HSTS, CORS, custom security headers) for a Fliplet app via Fliplet.App.Settings and the Developer Options panel.
+- [Custom HTML templates for Fliplet components](https://developers.fliplet.com/Custom-template-for-components.html): How to override a component's default template with custom HTML and Handlebars in the new container-based drag-and-drop system.
+- [Dependencies and assets](https://developers.fliplet.com/Dependencies-and-assets.html): Declare package dependencies and bundled JS/CSS/font assets for Fliplet components and themes, with separate interface and build entries plus appAssets.
+- [Testing Fliplet components](https://developers.fliplet.com/Testing-components.html): Run and write tests for a Fliplet component using the CLI's test command, backed by Mocha, Chai, and Puppeteer.
+- [UI guidelines for component output (build)](https://developers.fliplet.com/UI-guidelines-build.html): Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's user-facing output.
+- [UI guidelines for component settings (interface)](https://developers.fliplet.com/UI-guidelines-interface.html): Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's Studio settings interface.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-data-sources/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-data-sources/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: fliplet-data-sources
+description: Data sources JavaScript API and security model: query, insert, update, delete records; row-level security; file storage; data-source hooks.
+---
+
+# Fliplet data sources
+
+Data sources JavaScript API and security model: query, insert, update, delete records; row-level security; file storage; data-source hooks.
+
+## Documentation
+
+- [Data Source joins](https://developers.fliplet.com/API/datasources/joins.html): Fetch related rows from multiple data sources in a single query using named joins, like SQL joins.
+- [Data Sources query operators](https://developers.fliplet.com/API/datasources/query-operators.html): Filter Data Source queries with MongoDB/Sift operators ($eq, $gt, $in, $regex, $and, $or) inside connection.find() where clauses.
+- [Data Source views](https://developers.fliplet.com/API/datasources/views.html): Define named, session-aware filters on a data source so each user or group sees only the rows that apply to them.
+- [Fliplet.DataSources](https://developers.fliplet.com/API/fliplet-datasources.html): Connect to, query, insert, update, and delete records in Fliplet Data Sources from inside an app. All methods are promise-based.
+- [Fliplet infrastructure data flow](https://developers.fliplet.com/Data-flow.html): Architecture diagram showing how data flows between Fliplet Studio, Fliplet servers, app clients, and connected data sources.
+- [Data Source Hooks](https://developers.fliplet.com/Data-Source-Hooks.html): Trigger emails, SMS, push notifications, web requests, or column operations on Data Source insert/update/beforeSave/beforeQuery using Sift.js match conditions.
+- [Securing Fliplet data sources](https://developers.fliplet.com/Data-source-security.html): Secure your Data Sources with access rules, data requirements, and custom JavaScript security rules.
+- [Securing Fliplet files and folders](https://developers.fliplet.com/File-security.html): Secure files and folders in your Fliplet apps with access rules and custom JavaScript security rules.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-docs-index/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-docs-index/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: fliplet-docs-index
+description: Site-wide index of the Fliplet developer documentation. Use only as a fallback when no other Fliplet skill (js-api, rest-api, data-sources, app-actions, components-framework, helpers-framework, themes-framework, menus-framework, app-build-and-publish, security-and-compliance, integrations) matches your query. Points at /.well-known/llms.txt for full-site discovery.
+---
+
+# Fliplet developer documentation index
+
+Site-wide index of the Fliplet developer documentation. Use only as a fallback when no other Fliplet skill (js-api, rest-api, data-sources, app-actions, components-framework, helpers-framework, themes-framework, menus-framework, app-build-and-publish, security-and-compliance, integrations) matches your query. Points at /.well-known/llms.txt for full-site discovery.
+
+## Prefer a specific Fliplet skill
+
+Before loading this fallback skill, check whether one of the following matches your query:
+
+- `fliplet-data-sources` — Data sources JavaScript API and security model: query, insert, update, delete records; row-level security; file storage; data-source hooks.
+- `fliplet-app-actions` — Build server-side automations that run on a schedule or in response to events. Covers App Actions v1, v2, and v3 APIs.
+- `fliplet-helpers-framework` — Build helpers — reusable Vue-based interface components with editable interface fields, hooks, methods, libraries, and templates.
+- `fliplet-rest-api` — Server-side REST API for managing organizations, apps, users, data sources, files, and screens from your own backend.
+- `fliplet-components-framework` — Build custom components (widgets) that ship inside Fliplet apps: component definitions, lifecycle, events, dependencies, providers, custom templates, testing.
+- `fliplet-themes-framework` — Build custom themes that control app appearance: color palettes, typography, theme settings exposed in the editor, CSS overrides.
+- `fliplet-menus-framework` — Build custom menus that ship inside Fliplet apps to navigate between screens.
+- `fliplet-app-build-and-publish` — Publish Fliplet apps to iOS, Android, and the web: bundle size, certificates, automated app builds, platform-specific gotchas.
+- `fliplet-security-and-compliance` — App-level security, IP allowlisting, organization audit logs, privacy controls. (Data-source-level security lives in fliplet-data-sources.)
+- `fliplet-integrations` — Integrate with external systems: SSO/SAML2, the Data Integration Service, external REST APIs, OAuth2, AJAX cross-domain.
+- `fliplet-js-api` — The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User, Navigate, Profile, Communicate, Media, Notifications, UI, ...).
+
+## Full site index
+
+If no specific skill matches, fetch [https://developers.fliplet.com/.well-known/llms.txt](https://developers.fliplet.com/.well-known/llms.txt) for the complete list of every Fliplet developer doc, grouped by area. Each entry is a one-line summary; replace `.html` with `.md` on any doc URL to fetch the raw Markdown.
+
+## MCP server
+
+For tool-driven discovery, point an MCP-aware client at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp). The server exposes `search_fliplet_docs` and `fetch_fliplet_doc`.

--- a/docs/.well-known/agent-skills/fliplet-helpers-framework/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-helpers-framework/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: fliplet-helpers-framework
+description: Build helpers — reusable Vue-based interface components with editable interface fields, hooks, methods, libraries, and templates.
+---
+
+# Fliplet helpers framework
+
+Build helpers — reusable Vue-based interface components with editable interface fields, hooks, methods, libraries, and templates.
+
+## Documentation
+
+- [Distributing Helpers as components](https://developers.fliplet.com/API/helpers/components.html): Package a Fliplet Helper as a reusable widget-framework component so it can be installed and dropped into apps like any first-party component.
+- [Dynamic components](https://developers.fliplet.com/API/helpers/dynamic-components.html): Render Helper instances inside Dynamic Container and List Repeater components, with reactive per-record data binding via `supportsDynamicContext`.
+- [Helper example: decision tree](https://developers.fliplet.com/API/helpers/example-decision-tree.html): Worked example: build a decision-tree Helper that presents a question, waits for the user's answer, then advances to the next question.
+- [Helper example: question and answer](https://developers.fliplet.com/API/helpers/example-question.html): A worked example showing how to build a Helper that presents a multiple-choice question and reveals whether the selected answer is correct.
+- [Helper fields (attributes)](https://developers.fliplet.com/API/helpers/fields.html): Pass attributes to a Helper via the HTML `field` element and read them inside the Helper via `this.fields.<name>`.
+- [Helper lifecycle hooks and events](https://developers.fliplet.com/API/helpers/hooks.html): Run code at key points in a Helper's lifecycle using the `beforeReady` and `ready` render hooks.
+- [Helper configuration interface: fields](https://developers.fliplet.com/API/helpers/interface-fields.html): Define the fields shown in a Helper's Fliplet Studio configuration interface, including their type, label, validation, and default value.
+- [Helper configuration interface: hooks and events](https://developers.fliplet.com/API/helpers/interface-hooks.html): Run code when a Helper's configuration interface initializes, becomes ready, or is about to save.
+- [Helper configuration interface: external libraries](https://developers.fliplet.com/API/helpers/interface-libraries.html): Include Fliplet-approved or third-party JavaScript and CSS libraries in a Helper's configuration interface via the `dependencies` array.
+- [Helper configuration interface: methods](https://developers.fliplet.com/API/helpers/interface-methods.html): Use `find`, `findOne`, and `children` inside a Helper's configuration interface to access nested child Helper instances.
+- [Helper configuration interface](https://developers.fliplet.com/API/helpers/interface.html): Define a configuration UI for your Helper so users can set field values for each instance from within Fliplet Studio.
+- [Helper external libraries](https://developers.fliplet.com/API/helpers/libraries.html): Declare a Helper's runtime dependencies by listing Fliplet-approved or third-party JS/CSS libraries in its `render.dependencies` array.
+- [Helper instance and class methods](https://developers.fliplet.com/API/helpers/methods.html): Define instance methods on a Helper and call Helper class methods such as `find` and `findOne` anywhere in the app lifecycle.
+- [Fliplet Helpers overview](https://developers.fliplet.com/API/helpers/overview.html): Helpers are a UI framework for building custom components in Fliplet apps using JavaScript, with a configuration interface in Fliplet Studio.
+- [Fliplet Helpers quickstart](https://developers.fliplet.com/API/helpers/quickstart.html): Create your first Fliplet Helper by defining its name, template, and configuration object in screen or global JavaScript.
+- [Fliplet.Helper() constructor reference](https://developers.fliplet.com/API/helpers/references/constructor.html): Reference for `Fliplet.Helper()`: the constructor used to define a new Helper in a screen or globally across an app.
+- [Fliplet.Helper.field() reference](https://developers.fliplet.com/API/helpers/references/fields.html): Reference for `Fliplet.Helper.field()`: call this from a Helper's configuration interface to read or write the value of another field.
+- [Fliplet.Helper query methods reference](https://developers.fliplet.com/API/helpers/references/query.html): Reference for `Fliplet.Helper` query methods used to find Helper instances on the current screen from app code or from a configuration interface.
+- [Styling Helpers](https://developers.fliplet.com/API/helpers/style.html): Style a Helper using standard `class` and `style` HTML attributes — they are passed through to the rendered element rather than treated as Helper fields.
+- [Helper templates](https://developers.fliplet.com/API/helpers/templates.html): Every Helper defines an HTML template that renders it on screen, with support for variable binding, conditional blocks, and loops.
+- [Helper rich-content views](https://developers.fliplet.com/API/helpers/views.html): Define named rich-content views inside a Helper so app builders can drop approved child Helpers into specific regions of its layout.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-integrations/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-integrations/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fliplet-integrations
+description: Integrate with external systems: SSO/SAML2, the Data Integration Service, external REST APIs, OAuth2, AJAX cross-domain.
+---
+
+# Fliplet integrations
+
+Integrate with external systems: SSO/SAML2, the Data Integration Service, external REST APIs, OAuth2, AJAX cross-domain.
+
+## Documentation
+
+- [AJAX cross-domain and cross-origin requests](https://developers.fliplet.com/AJAX-cross-domain.html): How Fliplet apps handle AJAX cross-domain requests, common CORS errors, and the studio and app domains allowed by default.
+- [Fliplet.OAuth2 (Beta)](https://developers.fliplet.com/API/fliplet-oauth2.html): The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
+- [SAML2 Single Sign-On integration](https://developers.fliplet.com/API/integrations/sso-saml2.html): Add enterprise SSO to a Fliplet app with the SAML2 component, using an identity provider metadata XML exchange.
+- [Data integration service](https://developers.fliplet.com/Data-integration-service.html): Fliplet Agent (Data integration service) is a command line utility to synchronize data to and from Fliplet Servers.
+- [Integrating Fliplet apps with external APIs](https://developers.fliplet.com/Integrate-with-external-API.html): Call third-party REST APIs from a Fliplet app using jQuery AJAX helpers, including CORS considerations.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: fliplet-js-api
+description: The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User, Navigate, Profile, Communicate, Media, Notifications, UI, ...).
+---
+
+# Fliplet JavaScript API (Fliplet.*)
+
+The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User, Navigate, Profile, Communicate, Media, Notifications, UI, ...).
+
+## Documentation
+
+- [JS API Documentation](https://developers.fliplet.com/API-Documentation.html): Index of Fliplet's JavaScript APIs (Core, Data Sources, Media, UI, Communicate) for working with apps, screens, users, and components from custom code.
+- [Accordion component](https://developers.fliplet.com/API/components/accordions.html): The Accordion component supports query parameters to open specific accordions when linking to a screen.
+- [Charts component](https://developers.fliplet.com/API/components/charts.html): Use the Charts JS API to retrieve chart instances on a screen and update their data, labels, and series at runtime.
+- [Chat JS APIs](https://developers.fliplet.com/API/components/chat.html): Start conversations, list contacts, count unread messages, and modify chat rendering via Fliplet.Chat on screens that use the Chat layout component.
+- [Data Directory JS APIs](https://developers.fliplet.com/API/components/data-directory.html): Hook into the Data Directory component to override its data source, transform entries, and run code before render or initialization on directory screens.
+- [Dynamic Container JS APIs](https://developers.fliplet.com/API/components/dynamic-container.html): Bind a screen region to a data source query via Fliplet.DynamicContainer so the component renders a list of entries with bound expressions.
+- [Email Verification component](https://developers.fliplet.com/API/components/email-verification.html): Use the Email Verification JS API to retrieve the component instance on a screen and trigger verification flows for a given email address.
+- [Form JS APIs](https://developers.fliplet.com/API/components/form-builder.html): Populate fields, read values, react to validation, and submit programmatically via Fliplet.FormBuilder on screens that contain a Form component.
+- [Interactive Graphics JS APIs](https://developers.fliplet.com/API/components/interactive-graphics.html): Override marker data, preselect a marker or map, and respond to label clicks via Interactive Graphics component hooks on screens that use it.
+- [List (from Data Source) component](https://developers.fliplet.com/API/components/list-from-data-source.html): Configure templates, hooks, and query parameters for the List (from Data Source) component, which renders summary and detail views backed by a data source.
+- [List Repeater JS APIs](https://developers.fliplet.com/API/components/list-repeater.html): Render a list of data source entries inside a Dynamic Container via `Fliplet.ListRepeater`, with hooks to modify rows before and after render.
+- [Login](https://developers.fliplet.com/API/components/login.html): Run custom code after a user authenticates or when a returning user's session is re-validated via the Login component's `login` and `sessionValidate` hooks.
+- [Bottom Icon Bar menu component](https://developers.fliplet.com/API/components/menu-bottom-icon-bar.html): Use a query parameter to highlight the active item when linking into a screen that uses the Bottom Icon Bar menu component.
+- [Push Notifications JS APIs](https://developers.fliplet.com/API/components/push-notifications.html): Prompt users to subscribe, read device push settings, fetch the subscription ID and token, and unsubscribe via Fliplet's push notifications JS API.
+- [Record container JS APIs](https://developers.fliplet.com/API/components/record-container.html): Render a single data source entry in a screen via Fliplet.RecordContainer, with hooks to modify the query and react when data is retrieved.
+- [Fliplet.AI](https://developers.fliplet.com/API/core/ai.html): Build AI features with `Fliplet.AI` — chat, completions, streaming, image generation, transcription, and embeddings via OpenAI or Google Gemini proxies.
+- [Fliplet.Analytics](https://developers.fliplet.com/API/core/analytics.html): Enable, disable, and check analytics tracking, and record custom app events and page views from JavaScript.
+- [Fliplet.API.request()](https://developers.fliplet.com/API/core/api.html): Make authenticated HTTP requests to Fliplet APIs with automatic URL construction, caching, offline queueing, and error handling.
+- [Fliplet.App](https://developers.fliplet.com/API/core/app.html): Retrieve the current app's public slug, build shareable screen URLs, and access app-level settings from JavaScript.
+- [Fliplet.Apps](https://developers.fliplet.com/API/core/apps.html): List the Fliplet apps the current user can access, and filter between legacy V1 and modern V2 apps.
+- [Fliplet.User.Biometrics](https://developers.fliplet.com/API/core/biometrics.html): Check biometric availability and verify users with Face ID, Touch ID, or fingerprint inside native Fliplet apps.
+- [Fliplet.Cache](https://developers.fliplet.com/API/core/cache.html): Run async operations once and memoize their results, with optional expiry and background refresh.
+- [Fliplet.Encode](https://developers.fliplet.com/API/core/encode.html): Encode strings as base64 and double-encode URL query parameters safely for transport.
+- [Fliplet.Env](https://developers.fliplet.com/API/core/environment.html): Read environment variables such as `appId`, `appName`, `mode`, and `apiUrl` from the current runtime.
+- [Fliplet.parseError()](https://developers.fliplet.com/API/core/error.html): Turn any error response or object into a human-readable message by scanning common error properties.
+- [Fliplet.Hooks](https://developers.fliplet.com/API/core/hooks.html): Register callbacks that run before or after key app events (e.g. form submit), with sync or async Promise handlers.
+- [Fliplet.Locale](https://developers.fliplet.com/API/core/localization.html): Translate strings and format dates and numbers in Fliplet components via Fliplet.Locale, the T() shorthand, and translation.json files using i18next.
+- [Fliplet common functions](https://developers.fliplet.com/API/core/misc.html): Utility helpers on the global `Fliplet` object: `Fliplet.compile()` for templating and `Fliplet.guid()` for unique IDs.
+- [Fliplet.Modal](https://developers.fliplet.com/API/core/modal.html): Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio via `Fliplet.Modal`, powered by Bootbox.
+- [Fliplet.Navigate](https://developers.fliplet.com/API/core/navigate.html): Navigate between app screens, open external URLs, pass query parameters, and handle back, home, and modal navigation via Fliplet.Navigate.
+- [Fliplet.Navigator](https://developers.fliplet.com/API/core/navigator.html): Detect online/offline state, listen for connectivity changes, and wait for the device to be ready.
+- [Fliplet.Navigator.Notifications](https://developers.fliplet.com/API/core/notifications.html): Check notification support, request permission, and send local device notifications from JavaScript.
+- [Fliplet.Organizations](https://developers.fliplet.com/API/core/organizations.html): List the current user's organizations and fetch audit logs with filters for type, date range, app, and session.
+- [Fliplet Core overview](https://developers.fliplet.com/API/core/overview.html): Fliplet Core is the JS library bundled into every app screen — storage, navigation, user, API, and dozens of device helpers.
+- [Fliplet.Profile](https://developers.fliplet.com/API/core/profile.html): Read and write namespaced user profile attributes (email, name, company, phone) and fetch the device UUID.
+- [Fliplet.Registry](https://developers.fliplet.com/API/core/registry.html): Store and retrieve runtime values and functions by key so components can share state and helpers.
+- [`Fliplet.Pages` and `Fliplet.Page`](https://developers.fliplet.com/API/core/screens.html): List app screens, get the current screen's public URL, and build shareable URLs for any screen by ID.
+- [`Fliplet.Storage` and `Fliplet.App.Storage`](https://developers.fliplet.com/API/core/storage.html): Persist JSON-serializable values to device or browser storage, scoped globally or to the current app.
+- [Fliplet.Studio](https://developers.fliplet.com/API/core/studio.html): Emit events to Fliplet Studio and listen for events from it when building widget interfaces.
+- [Fliplet.User](https://developers.fliplet.com/API/core/user.html): Get and set the current user's auth token, profile details, and preferences, and sign the user out.
+- [Fliplet.Widget](https://developers.fliplet.com/API/core/widget.html): Access widget instance IDs, settings, and data, and coordinate save and ready events between widget and interface.
+- [Fliplet.Media.Audio.Player](https://developers.fliplet.com/API/fliplet-audio-player.html): Embed an audio player UI in a screen by tagging HTML elements with audio URLs; the framework auto-initializes players on screen load.
+- [Fliplet.Media.Audio](https://developers.fliplet.com/API/fliplet-audio.html): Play, pause, stop, and seek audio files on device or from a URL in Fliplet apps via the Audio namespace.
+- [Fliplet.Barcode](https://developers.fliplet.com/API/fliplet-barcode.html): Scan QR codes and other 1D/2D barcodes from the device camera via the fliplet-barcode package.
+- [Fliplet.Communicate](https://developers.fliplet.com/API/fliplet-communicate.html): Send email, SMS, push notifications, and share URLs from a Fliplet app using a single Communicate namespace.
+- [Fliplet.Content()](https://developers.fliplet.com/API/fliplet-content.html): Create, query, update, and delete shared content records (bookmarks, likes, saved searches) backed by a data source via Fliplet.Content.
+- [Fliplet.CSV](https://developers.fliplet.com/API/fliplet-csv.html): Encode and decode CSV in Fliplet apps via the fliplet-csv package.
+- [Fliplet.Database](https://developers.fliplet.com/API/fliplet-database.html): Low-level helper for reading and querying JSON data from a local file as a database; used internally by Fliplet.DataSources.
+- [Fliplet.DataSources.Encryption](https://developers.fliplet.com/API/fliplet-encryption.html): Automatically encrypt and decrypt selected Data Source columns on-device by registering a private key and column list.
+- [Fliplet.Gamify](https://developers.fliplet.com/API/fliplet-gamify.html): Configure gamification with logs, variables, and achievements via Fliplet.Gamify; track points, milestones, and badges backed by a data source per user.
+- [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.
+- [Fliplet.Notifications](https://developers.fliplet.com/API/fliplet-notifications.html): Read, send, and schedule in-app and push notifications in Fliplet apps, with support for scopes, read receipts, and badge counts.
+- [Fliplet.Page](https://developers.fliplet.com/API/fliplet-page.html): Utilities for interacting with the current Fliplet screen — including smooth-scrolling to an element with configurable duration and offsets.
+- [Fliplet.Payments](https://developers.fliplet.com/API/fliplet-payments.html): Accept Stripe payments and checkout in Fliplet apps via Fliplet.Payments, with a products data source and webhook-driven order tracking.
+- [Fliplet.Profile.Content()](https://developers.fliplet.com/API/fliplet-profile-content.html): Create, query, update, and delete user-attributed content records in a data source so each user only sees their own entries via Fliplet.Profile.Content.
+- [Fliplet.Session](https://developers.fliplet.com/API/fliplet-session.html): Read, write, and clear the current user session — including cached offline sessions — for authentication state in Fliplet apps.
+- [Fliplet.UI.Table](https://developers.fliplet.com/API/fliplet-table.html): Render searchable, sortable tables with pagination, row selection, expandable rows, and custom cell rendering via `Fliplet.UI.Table`.
+- [Fliplet.UI.Actions()](https://developers.fliplet.com/API/fliplet-ui-actions.html): Show a native-style action sheet with a title, labeled options, and a cancel button, resolving with the chosen index via Fliplet.UI.Actions.
+- [Fliplet.UI.AddressField()](https://developers.fliplet.com/API/fliplet-ui-address.html): Add a Google Maps autocomplete address field to a screen via `Fliplet.UI.AddressField()` to search, select, and retrieve location details.
+- [Fliplet.UI.DatePicker()](https://developers.fliplet.com/API/fliplet-ui-datepicker.html): Render a date picker input with optional preset value, required flag, and get/set/change methods via Fliplet.UI.DatePicker.
+- [Fliplet.UI.DateRange()](https://developers.fliplet.com/API/fliplet-ui-daterange.html): Render a paired start/end date range input with required flag, default value, and get/set/change methods via Fliplet.UI.DateRange.
+- [Fliplet.UI.NumberInput()](https://developers.fliplet.com/API/fliplet-ui-number.html): Render a numeric input with required flag, preset value, and get/set/change methods for reading user-entered numbers via Fliplet.UI.NumberInput.
+- [Fliplet.UI.PanZoom](https://developers.fliplet.com/API/fliplet-ui-panzoom.html): Pan, zoom, and place markers on images or interactive graphics via `Fliplet.UI.PanZoom`, with pinch, mouse wheel, and double-tap support.
+- [Fliplet.UI.RangeSlider()](https://developers.fliplet.com/API/fliplet-ui-rangeslider.html): Render a range slider input with min, max, step, and default value, plus get/set/change methods via Fliplet.UI.RangeSlider.
+- [Fliplet.UI.TimePicker()](https://developers.fliplet.com/API/fliplet-ui-timepicker.html): Render a time picker input in 24-hour HH:mm format with required flag and get/set/change methods via Fliplet.UI.TimePicker.
+- [Fliplet.UI.TimeRange()](https://developers.fliplet.com/API/fliplet-ui-timerange.html): Render a paired start/end time range input in HH:mm format with required flag, default value, and get/set/change methods via Fliplet.UI.TimeRange.
+- [Fliplet.UI.Toast.error()](https://developers.fliplet.com/API/fliplet-ui-toast-error.html): Parse an error object and show a toast with a friendly initial message plus a button to reveal the detailed technical error via Fliplet.UI.Toast.error.
+- [Fliplet.UI.Toast()](https://developers.fliplet.com/API/fliplet-ui-toast.html): Show minimal or regular auto-dismissing toast notifications with title, message, position, duration, progress bar, and action buttons via Fliplet.UI.Toast.
+- [Fliplet.UI.Typeahead()](https://developers.fliplet.com/API/fliplet-ui-typeahead.html): Render a typeahead input with real-time suggestions, free-input toggle, max items, and get/set/change methods via Fliplet.UI.Typeahead.
+- [Fliplet.UI](https://developers.fliplet.com/API/fliplet-ui.html): Fliplet-managed UI primitives — toasts, action sheets, modals, date/time pickers, typeahead, tables, panzoom — under the Fliplet.UI namespace.
+- [Using Handlebars in your apps](https://developers.fliplet.com/API/libraries/handlebars.html): Use Handlebars 2.15.2 in Fliplet app screens for templating, with built-in helpers for images, dates, auth URLs, JSON, and conditional comparisons.
+- [Fliplet.LikeButton](https://developers.fliplet.com/API/like-buttons.html): Embed a one-tap like button on any screen element, backed by a Data Source that records likes per content ID.
+- [Data Source provider](https://developers.fliplet.com/API/providers/data-source.html): The Data Source provider lets users pick or create a data source for a component, including default columns, entries, and access rules.
+- [Email provider](https://developers.fliplet.com/API/providers/email.html): Compose email templates (subject, body, recipients, headers) in a reusable provider UI for sending via `Fliplet.Communicate.sendEmail()`.
+- [File Picker provider](https://developers.fliplet.com/API/providers/file-picker.html): The File Picker provider lets users select one or more files from Fliplet's File Manager, optionally scoped by file type or restricted to single-select.
+- [Link Action provider](https://developers.fliplet.com/API/providers/link-action.html): Configure link actions (navigate to screen, open URL, document, video, or run JS) in a reusable provider UI executable via `Fliplet.Navigate.to()`.
+- [Fliplet-approved JavaScript libraries (coding-standards edition)](https://developers.fliplet.com/approved-libraries.html): The JavaScript libraries Fliplet pre-approves for app development, why you should prefer them over custom ones, and when to reach for each.
+- [Fliplet API patterns and categories](https://developers.fliplet.com/code-api-patterns.html): Overview of the main Fliplet JS API categories (Data Sources, Users, Media, Navigation) and when to pick each one.
+- [Fliplet-approved JavaScript libraries (reference list)](https://developers.fliplet.com/Fliplet-approved-libraries.html): Reference list of every JavaScript library Fliplet pre-approves in apps, including versions and optional add-on libraries.
+- [Fliplet SDK](https://developers.fliplet.com/Fliplet-SDK.html): Load Fliplet JS APIs on any external website via sdk.js with an auth token and optional comma-separated package list (e.g. fliplet-media, fliplet-datasources).
+- [The Fliplet JavaScript APIs](https://developers.fliplet.com/JS-APIs.html): How the Fliplet JS APIs (SDK, not a framework) let you interact with data, screens, users, and components from Studio custom code, themes, and widgets.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-menus-framework/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-menus-framework/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: fliplet-menus-framework
+description: Build custom menus that ship inside Fliplet apps to navigate between screens.
+---
+
+# Fliplet menus framework
+
+Build custom menus that ship inside Fliplet apps to navigate between screens.
+
+## Documentation
+
+- [Building Fliplet menus](https://developers.fliplet.com/Building-menus.html): How to scaffold a Fliplet menu widget, configure its position and settings via menu.json, and develop its template and assets.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-rest-api/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-rest-api/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: fliplet-rest-api
+description: Server-side REST API for managing organizations, apps, users, data sources, files, and screens from your own backend.
+---
+
+# Fliplet REST API
+
+Server-side REST API for managing organizations, apps, users, data sources, files, and screens from your own backend.
+
+## Documentation
+
+- [Rate limiting for APIs](https://developers.fliplet.com/Rate-limiting-for-API.html): Fliplet rate-limits Data Source, Communicate, audit-log, AI, and App Action APIs per user; back off on 429 responses and batch writes via the commit endpoint.
+- [Fliplet REST API documentation](https://developers.fliplet.com/REST-API-Documentation.html): Index of Fliplet REST endpoints for Data Sources, Media, Notifications, Apps, and more — intended for third-party integrations.
+- [Authenticating with the Fliplet REST APIs](https://developers.fliplet.com/REST-API/authenticate.html): Authenticate Fliplet REST API requests via Auth-token header, Authorization Bearer (base64), query string, or cookie against EU, US, or CA endpoints.
+- [App Analytics REST API](https://developers.fliplet.com/REST-API/fliplet-app-analytics.html): The App Analytics REST API lets you read your app's analytics data.
+- [App Subscriptions REST API](https://developers.fliplet.com/REST-API/fliplet-app-subscriptions.html): The App Subscriptions REST API lets you read and manage your app's users subscribed via push notifications.
+- [Apps REST API](https://developers.fliplet.com/REST-API/fliplet-apps.html): The Apps REST API lets external integrations list, read, create, update, and delete Fliplet apps that the auth token has access to.
+- [Communicate REST API](https://developers.fliplet.com/REST-API/fliplet-communicate.html): The Communicate REST API lets external integrations send emails and SMS from a Fliplet app, subject to per-account rate limits.
+- [Data Sources REST API](https://developers.fliplet.com/REST-API/fliplet-datasources.html): The Data Sources REST API lets external integrations read and modify the data sources belonging to a Fliplet app or organization.
+- [Media REST API](https://developers.fliplet.com/REST-API/fliplet-media.html): The Media REST API lets external integrations upload, list, and manage media files and folders scoped to a Fliplet app or organization.
+- [Notifications REST API](https://developers.fliplet.com/REST-API/fliplet-notifications.html): The Notifications REST API lets external integrations create, schedule, and publish in-app and push notifications to Fliplet app users.
+- [Organizations REST API](https://developers.fliplet.com/REST-API/fliplet-organizations.html): The Organizations REST API lets external integrations read audit logs and manage resources belonging to a Fliplet organization.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-security-and-compliance/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-security-and-compliance/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: fliplet-security-and-compliance
+description: App-level security, IP allowlisting, organization audit logs, privacy controls. (Data-source-level security lives in fliplet-data-sources.)
+---
+
+# Fliplet security and compliance
+
+App-level security, IP allowlisting, organization audit logs, privacy controls. (Data-source-level security lives in fliplet-data-sources.)
+
+## Documentation
+
+- [Securing your apps](https://developers.fliplet.com/App-security.html): Restrict screen and data-source access in Fliplet apps via login conditions, IP allow/deny lists, and custom JS rules using session and page context.
+- [Organization audit log types](https://developers.fliplet.com/Organization-audit-log-types.html): Reference table of every audit log type emitted for Fliplet organizations, queryable via the JS or REST API.
+- [Fliplet URLs and IP addresses](https://developers.fliplet.com/URLs-and-IP-Addresses.html): Domains and ports that Fliplet Studio, web apps, native apps, and the Data Integration Service need reachable through a corporate firewall.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/fliplet-themes-framework/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-themes-framework/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: fliplet-themes-framework
+description: Build custom themes that control app appearance: color palettes, typography, theme settings exposed in the editor, CSS overrides.
+---
+
+# Fliplet themes framework
+
+Build custom themes that control app appearance: color palettes, typography, theme settings exposed in the editor, CSS overrides.
+
+## Documentation
+
+- [Fliplet.Themes](https://developers.fliplet.com/API/fliplet-themes.html): Read the list of available app themes and access the current theme's settings and widget-instance values at runtime.
+- [Building Fliplet themes](https://developers.fliplet.com/Building-themes.html): How to scaffold a Fliplet theme, configure its customizable settings from Studio, and preview sample HTML during local development.
+- [Use theme settings in your custom CSS](https://developers.fliplet.com/Theme-Settings-In-CSS.html): Reference Fliplet theme SCSS variables (colors, typography, spacing) inside your custom CSS to inherit the theme's settings on a specific screen.
+- [Theme and appearance settings for components](https://developers.fliplet.com/Theming-appearance.html): Expose configurable colors, fonts, and other CSS properties in Fliplet Studio's theme settings UI via your component's widget.json.
+
+## How to load full content
+
+Replace `.html` with `.md` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [https://developers.fliplet.com/mcp](https://developers.fliplet.com/mcp) (tools: `search_fliplet_docs`, `fetch_fliplet_doc`), or fetch [https://developers.fliplet.com/.well-known/llms-full.txt](https://developers.fliplet.com/.well-known/llms-full.txt) for the entire site as a single stream.

--- a/docs/.well-known/agent-skills/index.json
+++ b/docs/.well-known/agent-skills/index.json
@@ -1,1216 +1,149 @@
 {
-  "$schema": "https://agentskills.io/schema/v0.2.0/index.json",
   "skills": [
     {
-      "name": "readme",
-      "type": "documentation",
-      "description": "Reference and guides for extending Fliplet apps with the JS API, REST API, and custom components, themes, and menus.",
-      "url": "https://developers.fliplet.com/",
-      "sha256": "998f473baa51f0976d1c562fbb6e272cd817668e7c046098b78cca8a9fe84a48"
-    },
-    {
-      "name": "aab-create-p12-certificate",
-      "type": "documentation",
-      "description": "Generate a P12 signing key from an Apple Enterprise account to supply to Fliplet's Automated App Build system.",
-      "url": "https://developers.fliplet.com/aab/create-p12-certificate.html",
-      "sha256": "2cc74ef43201b85c097c950fea3a52f6f987d08e736e217a1d7a5e349b5bbdd0"
-    },
-    {
-      "name": "ai-powered-development-with-cursor",
-      "type": "documentation",
-      "description": "How to install and use the Fliplet VS Code extension inside Cursor to generate, refactor, and debug Fliplet app code with AI assistance.",
-      "url": "https://developers.fliplet.com/AI-powered-development-with-Cursor.html",
-      "sha256": "ab2298095c0583b5a79404f1f1236cc80f1ecfdfc29e4c260f1fef4af1be4990"
-    },
-    {
-      "name": "ajax-cross-domain",
-      "type": "documentation",
-      "description": "How Fliplet apps handle AJAX cross-domain requests, common CORS errors, and the studio and app domains allowed by default.",
-      "url": "https://developers.fliplet.com/AJAX-cross-domain.html",
-      "sha256": "0e07b3aea6f3b759e168bc1681b4a4b5269d54937fecfae500f3d5b09899511e"
-    },
-    {
-      "name": "analytics-documentation",
-      "type": "documentation",
-      "description": "Reference list of analytics event types Fliplet emits for page views, navigation, app management, sharing, and component interactions.",
-      "url": "https://developers.fliplet.com/Analytics-documentation.html",
-      "sha256": "09b8606ad0db222fbcdd73178d72c6091a101ff5ab3bf14225aa51a388767e53"
-    },
-    {
-      "name": "api-documentation",
-      "type": "documentation",
-      "description": "Javascript-based SDK to interact with core functions and components in your Fliplet Apps.",
-      "url": "https://developers.fliplet.com/API-Documentation.html",
-      "sha256": "6a7bde7b12eb4885538467e67591574f49b34fa0761c4508071f40882311be62"
-    },
-    {
-      "name": "api-components-accordions",
-      "type": "documentation",
-      "description": "The Accordion component supports query parameters to open specific accordions when linking to a screen.",
-      "url": "https://developers.fliplet.com/API/components/accordions.html",
-      "sha256": "735712803089b1ea8e004ac4dad7957754b810d680360bfff7511eb6653aea6c"
-    },
-    {
-      "name": "api-components-charts",
-      "type": "documentation",
-      "description": "Use the Charts JS API to retrieve chart instances on a screen and update their data, labels, and series at runtime.",
-      "url": "https://developers.fliplet.com/API/components/charts.html",
-      "sha256": "070425c119d9a562cf5e3d4b296ad86188f1182086771639a35ddc4454c66509"
-    },
-    {
-      "name": "api-components-chat",
-      "type": "documentation",
-      "description": "These public JS APIs will be automatically available in your screens once a **Chat layout** component is used. You can also include these by manually adding th…",
-      "url": "https://developers.fliplet.com/API/components/chat.html",
-      "sha256": "7d40e62f124a33123403dba76ce1c7d2404c641e5f4b8953ee4c348efb4c2dad"
-    },
-    {
-      "name": "api-components-data-directory",
-      "type": "documentation",
-      "description": "These public JS APIs will be automatically available in your screens once a **Data Directory** component is dropped into such screens.",
-      "url": "https://developers.fliplet.com/API/components/data-directory.html",
-      "sha256": "7a58254654475c9b0c33625626c58d3f79221937b9879add932571edc73e217c"
-    },
-    {
-      "name": "api-components-dynamic-container",
-      "type": "documentation",
-      "description": "The dynamic container allows you to dynamically load data from a data source in a screen. It is useful when you want to display a list of records in a screen u…",
-      "url": "https://developers.fliplet.com/API/components/dynamic-container.html",
-      "sha256": "c1c52f8c35d393a5df13a68f33aa76369673be80192f5825852dcca932228974"
-    },
-    {
-      "name": "api-components-email-verification",
-      "type": "documentation",
-      "description": "Use the Email Verification JS API to retrieve the component instance on a screen and trigger verification flows for a given email address.",
-      "url": "https://developers.fliplet.com/API/components/email-verification.html",
-      "sha256": "5176d351dc482ba09ed40e44f87be90a13acb6cc17b4b1074142f841bcd1dde2"
-    },
-    {
-      "name": "api-components-form-builder",
-      "type": "documentation",
-      "description": "The following JS APIs are available in a screen once a **Form** component is dropped into the screen.",
-      "url": "https://developers.fliplet.com/API/components/form-builder.html",
-      "sha256": "8c45db30756bcd25b44a121ccd9265b4f84729c9781034d54b0096c1be3b7c76"
-    },
-    {
-      "name": "api-components-interactive-graphics",
-      "type": "documentation",
-      "description": "These public JS APIs are available in screens where an **Interactive Graphics** component is present.",
-      "url": "https://developers.fliplet.com/API/components/interactive-graphics.html",
-      "sha256": "1cc5c249aa863393b2be3419d7dc1bfb1ecf3629a6faa2b8439741acc4fb8a46"
-    },
-    {
-      "name": "api-components-list-from-data-source",
-      "type": "documentation",
-      "description": "Configure templates, hooks, and query parameters for the List (from Data Source) component, which renders summary and detail views backed by a data source.",
-      "url": "https://developers.fliplet.com/API/components/list-from-data-source.html",
-      "sha256": "3bfe2491a543592909afad9bf4109ce10180a0e5e7aa97da402ca41dde09b1d1"
-    },
-    {
-      "name": "api-components-list-repeater",
-      "type": "documentation",
-      "description": "The list repeater component is a container for a list of records. It is used to display a list of records from a data source.",
-      "url": "https://developers.fliplet.com/API/components/list-repeater.html",
-      "sha256": "74dcc2e1e0127499cb05c7fff21daed18b3fc684587b2e4df84a20d879724720"
-    },
-    {
-      "name": "api-components-login",
-      "type": "documentation",
-      "description": "The login component fires hooks at key points in the authentication lifecycle. These allow you to run custom code after a user successfully logs in or when a r…",
-      "url": "https://developers.fliplet.com/API/components/login.html",
-      "sha256": "359ee218ff45702d24b2fff355bbdf4a250087493516dc0ea4a1bf608500c89f"
-    },
-    {
-      "name": "api-components-menu-bottom-icon-bar",
-      "type": "documentation",
-      "description": "Use a query parameter to highlight the active item when linking into a screen that uses the Bottom Icon Bar menu component.",
-      "url": "https://developers.fliplet.com/API/components/menu-bottom-icon-bar.html",
-      "sha256": "581b73e7272dec5ae116d6fbe6d8378a21222c1d68433b80b580ddcbf5ec230d"
-    },
-    {
-      "name": "api-components-push-notifications",
-      "type": "documentation",
-      "description": "These public JS APIs will be automatically available in your screens once **Push Notifications** have been enabled for your app.",
-      "url": "https://developers.fliplet.com/API/components/push-notifications.html",
-      "sha256": "61693dbd69c3ba3c2b13213baa855a5a197d9eaebaaafb23792f85a3f09cc701"
-    },
-    {
-      "name": "api-components-record-container",
-      "type": "documentation",
-      "description": "The record container allows you to display one record from a data source in a screen. It is useful when you want to display a single record in a screen, for ex…",
-      "url": "https://developers.fliplet.com/API/components/record-container.html",
-      "sha256": "9958fa15e2d695f42ef7ea3f92c3332015e041173c262afdb1efd3a0190a2ddf"
-    },
-    {
-      "name": "api-core-ai",
-      "type": "documentation",
-      "description": "Build AI features in Fliplet apps with chat, completions, streaming, and task helpers — backed by OpenAI (GPT, o-series) or Google Gemini models via direct pro…",
-      "url": "https://developers.fliplet.com/API/core/ai.html",
-      "sha256": "496edbaad277788269b345027715a94d58f4c7cbf8c9bc9310611420a587f6b8"
-    },
-    {
-      "name": "api-core-analytics",
-      "type": "documentation",
-      "description": "Enable, disable, and check analytics tracking, and record custom app events and page views from JavaScript.",
-      "url": "https://developers.fliplet.com/API/core/analytics.html",
-      "sha256": "2bcbad69f35711aad4718ed69d1730acc5e673b20d5db3246ef4a61146a5ba59"
-    },
-    {
-      "name": "api-core-api",
-      "type": "documentation",
-      "description": "Make authenticated HTTP requests to Fliplet APIs with automatic URL construction, caching, offline queueing, and error handling.",
-      "url": "https://developers.fliplet.com/API/core/api.html",
-      "sha256": "bf7206fc85358b755c8b509885c1198a6a412b0794455115f82de7258b818655"
-    },
-    {
-      "name": "api-core-app-actions-v2",
-      "type": "documentation",
-      "description": "Deprecated App Actions V2 — configure a pipeline of functions that runs on-device or in the cloud, ad hoc or on a schedule. Migrate to V3.",
-      "url": "https://developers.fliplet.com/API/core/app-actions-v2.html",
-      "sha256": "69924b3469cbc56a41c6b0bb25b40d5b09843a9660bee0dfff7f9bbecbf1512e"
-    },
-    {
-      "name": "api-core-app-actions-v3",
-      "type": "documentation",
-      "description": "Write and run JavaScript code directly on the server or client to perform automations, scheduled tasks and on-demand operations.",
-      "url": "https://developers.fliplet.com/API/core/app-actions-v3.html",
-      "sha256": "988b5028036a9a78de13e48a229111d9c0fdd48b04df6746ce677f64cdb64faa"
-    },
-    {
-      "name": "api-core-app-actions",
-      "type": "documentation",
-      "description": "Deprecated App Actions V1 — run app screens automatically on a schedule or on demand in the cloud. Migrate to V3.",
-      "url": "https://developers.fliplet.com/API/core/app-actions.html",
-      "sha256": "c5f1842d476ba981eb5b97968a0ffa18661aaaa29084c8c5a9f553a840240b87"
-    },
-    {
-      "name": "api-core-app",
-      "type": "documentation",
-      "description": "Retrieve the current app's public slug, build shareable screen URLs, and access app-level settings from JavaScript.",
-      "url": "https://developers.fliplet.com/API/core/app.html",
-      "sha256": "db98daf4b8aee7234954ff741d8bc636a27be2892e39c7b5364bdfa4dff922a0"
-    },
-    {
-      "name": "api-core-apps",
-      "type": "documentation",
-      "description": "List the Fliplet apps the current user can access, and filter between legacy V1 and modern V2 apps.",
-      "url": "https://developers.fliplet.com/API/core/apps.html",
-      "sha256": "e69c35f7e0ac282c8ca3d4c423c049297fb9d00eca183137c1a60480a786f56b"
-    },
-    {
-      "name": "api-core-biometrics",
-      "type": "documentation",
-      "description": "Check biometric availability and verify users with Face ID, Touch ID, or fingerprint inside native Fliplet apps.",
-      "url": "https://developers.fliplet.com/API/core/biometrics.html",
-      "sha256": "9042c1ba6cef74b02025520c4baca7f274e09ec547c78e29d9da65af50fa5071"
-    },
-    {
-      "name": "api-core-cache",
-      "type": "documentation",
-      "description": "Run async operations once and memoize their results, with optional expiry and background refresh.",
-      "url": "https://developers.fliplet.com/API/core/cache.html",
-      "sha256": "306ede564c35aa5bdd3925fc612e473a04b06315439122918adc117b1b65292f"
-    },
-    {
-      "name": "api-core-encode",
-      "type": "documentation",
-      "description": "Encode strings as base64 and double-encode URL query parameters safely for transport.",
-      "url": "https://developers.fliplet.com/API/core/encode.html",
-      "sha256": "97288f1434e2a5384f498a5d835ace78da6fa3ce5b23ed9942bd4860e60e8cd0"
-    },
-    {
-      "name": "api-core-environment",
-      "type": "documentation",
-      "description": "Read environment variables such as `appId`, `appName`, `mode`, and `apiUrl` from the current runtime.",
-      "url": "https://developers.fliplet.com/API/core/environment.html",
-      "sha256": "52cf6707d682343e765f1b43c4e7e02c57c076c5d85857d622f20d2837c5d989"
-    },
-    {
-      "name": "api-core-error",
-      "type": "documentation",
-      "description": "Turn any error response or object into a human-readable message by scanning common error properties.",
-      "url": "https://developers.fliplet.com/API/core/error.html",
-      "sha256": "a18d4fd22d93c2b97a3dc333dc04169e29ab3761f9c32949483882263481691a"
-    },
-    {
-      "name": "api-core-hooks",
-      "type": "documentation",
-      "description": "Register callbacks that run before or after key app events (e.g. form submit), with sync or async Promise handlers.",
-      "url": "https://developers.fliplet.com/API/core/hooks.html",
-      "sha256": "567ce744e004ae59ed807fb2531c85f5395427d85a6412a00fe89a19fd42d625"
-    },
-    {
-      "name": "api-core-localization",
-      "type": "documentation",
-      "description": "Customize your component to localize to different languages and regions.",
-      "url": "https://developers.fliplet.com/API/core/localization.html",
-      "sha256": "16b1b650afd2491341c403379617c8609d691261eebb1d0e4db55f5fe903b15b"
-    },
-    {
-      "name": "api-core-misc",
-      "type": "documentation",
-      "description": "Utility helpers on the global `Fliplet` object: `Fliplet.compile()` for templating and `Fliplet.guid()` for unique IDs.",
-      "url": "https://developers.fliplet.com/API/core/misc.html",
-      "sha256": "7ffdb683a8826c811337e762c1851828833d65ee21207283eb56fc0c19c8dfc8"
-    },
-    {
-      "name": "api-core-modal",
-      "type": "documentation",
-      "description": "Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio, powered by [Bootbox](http://bootboxjs.com/) — see its documentation for…",
-      "url": "https://developers.fliplet.com/API/core/modal.html",
-      "sha256": "2f18e8ba653f51fd60b80425afb3edaf656a35d966eb38281c828b6d4a98fcf2"
-    },
-    {
-      "name": "api-core-navigate",
-      "type": "documentation",
-      "description": "Navigate the app to a new page, screen, document or URL",
-      "url": "https://developers.fliplet.com/API/core/navigate.html",
-      "sha256": "e52e2eef13244591c501f670fea87c8be76bfa109538a71db8c64641eae829fa"
-    },
-    {
-      "name": "api-core-navigator",
-      "type": "documentation",
-      "description": "Detect online/offline state, listen for connectivity changes, and wait for the device to be ready.",
-      "url": "https://developers.fliplet.com/API/core/navigator.html",
-      "sha256": "8ec6af19eb6be7e4f3d4687defd50253e1baa2bd14da47c406c08273f7b95016"
-    },
-    {
-      "name": "api-core-notifications",
-      "type": "documentation",
-      "description": "Check notification support, request permission, and send local device notifications from JavaScript.",
-      "url": "https://developers.fliplet.com/API/core/notifications.html",
-      "sha256": "72d027b225386ada41267ee8e22025cf5d6bed8cdc6b5b72eb943ab5b1a1fb45"
-    },
-    {
-      "name": "api-core-organizations",
-      "type": "documentation",
-      "description": "List the current user's organizations and fetch audit logs with filters for type, date range, app, and session.",
-      "url": "https://developers.fliplet.com/API/core/organizations.html",
-      "sha256": "a2b62d404ebcee324dcd0dc07c2c747c88c7cde5334875ef72637f255b72efab"
-    },
-    {
-      "name": "api-core-overview",
-      "type": "documentation",
-      "description": "Fliplet Core is the JS library bundled into every app screen — storage, navigation, user, API, and dozens of device helpers.",
-      "url": "https://developers.fliplet.com/API/core/overview.html",
-      "sha256": "b06afa88a7ec6c81c64d068012c023a54c9df3b557248deb92214d257db49216"
-    },
-    {
-      "name": "api-core-profile",
-      "type": "documentation",
-      "description": "Read and write namespaced user profile attributes (email, name, company, phone) and fetch the device UUID.",
-      "url": "https://developers.fliplet.com/API/core/profile.html",
-      "sha256": "91325ddd367732bca1390a702b372588bc87fd721fa48cf10dfc8b5efdb36018"
-    },
-    {
-      "name": "api-core-registry",
-      "type": "documentation",
-      "description": "Store and retrieve runtime values and functions by key so components can share state and helpers.",
-      "url": "https://developers.fliplet.com/API/core/registry.html",
-      "sha256": "3481632fcf42f893a4a378d8b200b7b6e1c2361773754e673ff9a2dbddb23343"
-    },
-    {
-      "name": "api-core-screens",
-      "type": "documentation",
-      "description": "List app screens, get the current screen's public URL, and build shareable URLs for any screen by ID.",
-      "url": "https://developers.fliplet.com/API/core/screens.html",
-      "sha256": "5f7955da4d031527df5e67282cf0cce1f9bbcc944c57d937b79529ad932ce064"
-    },
-    {
-      "name": "api-core-storage",
-      "type": "documentation",
-      "description": "Persist JSON-serializable values to device or browser storage, scoped globally or to the current app.",
-      "url": "https://developers.fliplet.com/API/core/storage.html",
-      "sha256": "42addbdc04a8af8eb355edaa92642c162a847f4def295b5f57ded5f1f086f06a"
-    },
-    {
-      "name": "api-core-studio",
-      "type": "documentation",
-      "description": "Emit events to Fliplet Studio and listen for events from it when building widget interfaces.",
-      "url": "https://developers.fliplet.com/API/core/studio.html",
-      "sha256": "42ab290840fc0b6c719873dcdf4e4f346e9532b522ed2555af8e274cfe837cf2"
-    },
-    {
-      "name": "api-core-user",
-      "type": "documentation",
-      "description": "Get and set the current user's auth token, profile details, and preferences, and sign the user out.",
-      "url": "https://developers.fliplet.com/API/core/user.html",
-      "sha256": "3de4a372adf27544c52c6ebc3884e1599ebbcde54fb74aa66284c0a36fbc9aad"
-    },
-    {
-      "name": "api-core-widget",
-      "type": "documentation",
-      "description": "Access widget instance IDs, settings, and data, and coordinate save and ready events between widget and interface.",
-      "url": "https://developers.fliplet.com/API/core/widget.html",
-      "sha256": "621498ba1085012895fdae0103ab7fb733885ea7ed877669967bd15f1f9941d8"
-    },
-    {
-      "name": "api-datasources-joins",
-      "type": "documentation",
-      "description": "Fetch related rows from multiple data sources in a single query using named joins, like SQL joins.",
-      "url": "https://developers.fliplet.com/API/datasources/joins.html",
-      "sha256": "233961faff440779e03defd971fde4e8bab772b34af62b3a1965be9ea380c3c2"
-    },
-    {
-      "name": "api-datasources-query-operators",
-      "type": "documentation",
-      "description": "Reference for MongoDB/Sift-style operators (`$eq`, `$gt`, `$in`, `$regex`, …) usable in `connection.find()` `where` clauses.",
-      "url": "https://developers.fliplet.com/API/datasources/query-operators.html",
-      "sha256": "722f77550a592f7b4d5fdc83b862ab31c0f4633ca5654d062fccdf988ea3e129"
-    },
-    {
-      "name": "api-datasources-views",
-      "type": "documentation",
-      "description": "Define named, session-aware filters on a data source so each user or group sees only the rows that apply to them.",
-      "url": "https://developers.fliplet.com/API/datasources/views.html",
-      "sha256": "d722ea2842b3ea42aa859921e97adf103b6c11adcc74dce1aa4e4bc87d99f36a"
-    },
-    {
-      "name": "api-fliplet-audio-player",
-      "type": "documentation",
-      "description": "Embed an audio player UI in a screen by tagging HTML elements with audio URLs; the framework auto-initializes players on screen load.",
-      "url": "https://developers.fliplet.com/API/fliplet-audio-player.html",
-      "sha256": "1a26439e422ae0ac22480d9c48a463571f9cb740cc097d4d4c3041df725b6d2d"
-    },
-    {
-      "name": "api-fliplet-audio",
-      "type": "documentation",
-      "description": "Play, pause, stop, and seek audio files on device or from a URL in Fliplet apps via the Audio namespace.",
-      "url": "https://developers.fliplet.com/API/fliplet-audio.html",
-      "sha256": "aee61adc098949b209661de5d4675a83a40094eaaf77c3b6c4b80be0619c2174"
-    },
-    {
-      "name": "api-fliplet-barcode",
-      "type": "documentation",
-      "description": "Scan QR codes and other 1D/2D barcodes from the device camera via the fliplet-barcode package.",
-      "url": "https://developers.fliplet.com/API/fliplet-barcode.html",
-      "sha256": "aac6c183eb58ff724fb89a68f9cbb56e788885387e63a914626ba47547cccd20"
-    },
-    {
-      "name": "api-fliplet-communicate",
-      "type": "documentation",
-      "description": "Send email, SMS, push notifications, and share URLs from a Fliplet app using a single Communicate namespace.",
-      "url": "https://developers.fliplet.com/API/fliplet-communicate.html",
-      "sha256": "e47da0072cf9b654c9de39d889a6d250374fa761581e30dc587cbca106b83ea0"
-    },
-    {
-      "name": "api-fliplet-content",
-      "type": "documentation",
-      "description": "(Returns **`Promise`**)",
-      "url": "https://developers.fliplet.com/API/fliplet-content.html",
-      "sha256": "beecf3b18f31691f64816a3bb035e618c0e007bb7946cd51a8d320ad8b62da81"
-    },
-    {
-      "name": "api-fliplet-csv",
-      "type": "documentation",
-      "description": "Encode and decode CSV in Fliplet apps via the fliplet-csv package.",
-      "url": "https://developers.fliplet.com/API/fliplet-csv.html",
-      "sha256": "8d882bca18362eac2eff00634ed6ee270dc7675804714d6e2d4d99fb84e974af"
-    },
-    {
-      "name": "api-fliplet-database",
-      "type": "documentation",
-      "description": "Low-level helper for reading and querying JSON data from a local file as a database; used internally by Fliplet.DataSources.",
-      "url": "https://developers.fliplet.com/API/fliplet-database.html",
-      "sha256": "d7409e81b90667b3631fc59331a3e8edbd169ec4203138eddb2a592b7d6a0b67"
-    },
-    {
-      "name": "api-fliplet-datasources",
-      "type": "documentation",
-      "description": "Connect to, query, insert, update, and delete records in Fliplet Data Sources from inside an app. All methods are promise-based.",
-      "url": "https://developers.fliplet.com/API/fliplet-datasources.html",
-      "sha256": "1902741a06d4503640d548eeb5abd9a6862897e69ae7a8d056d1d6fbba3d2a2e"
-    },
-    {
-      "name": "api-fliplet-encryption",
-      "type": "documentation",
-      "description": "Automatically encrypt and decrypt selected Data Source columns on-device by registering a private key and column list.",
-      "url": "https://developers.fliplet.com/API/fliplet-encryption.html",
-      "sha256": "2dc059b6f0a25a3b428bc97800bd360d3a19a77708ffeb6ede9840b861900eae"
-    },
-    {
-      "name": "api-fliplet-gamify",
-      "type": "documentation",
-      "description": "Configure gamification logic for your apps.",
-      "url": "https://developers.fliplet.com/API/fliplet-gamify.html",
-      "sha256": "575c4d7e8cf7887c44d705c5e078931fa26164c62097f8687c85f749a7cfe402"
-    },
-    {
-      "name": "api-fliplet-media",
-      "type": "documentation",
-      "description": "Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.",
-      "url": "https://developers.fliplet.com/API/fliplet-media.html",
-      "sha256": "29d4ec604f39a0f81cfbedbe13dda9adbd10cc7d9ffe8fb456c53a0848717ada"
-    },
-    {
-      "name": "api-fliplet-notifications",
-      "type": "documentation",
-      "description": "Read, send, and schedule in-app and push notifications in Fliplet apps, with support for scopes, read receipts, and badge counts.",
-      "url": "https://developers.fliplet.com/API/fliplet-notifications.html",
-      "sha256": "d33f42ca3558fa590a9429d422adb85e9e0de39908e224f3a4f2023d1c51798c"
-    },
-    {
-      "name": "api-fliplet-oauth2",
-      "type": "documentation",
-      "description": "The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.",
-      "url": "https://developers.fliplet.com/API/fliplet-oauth2.html",
-      "sha256": "3726db605a39a157443ba2a9c771c8565cfe3e54be1c4f82ebf29deb02ae2632"
-    },
-    {
-      "name": "api-fliplet-page",
-      "type": "documentation",
-      "description": "Utilities for interacting with the current Fliplet screen — including smooth-scrolling to an element with configurable duration and offsets.",
-      "url": "https://developers.fliplet.com/API/fliplet-page.html",
-      "sha256": "0926fd83ba2b2f7366e9bedc926175f3a722e171aa2455513a9b0c1575e1d6f8"
-    },
-    {
-      "name": "api-fliplet-payments",
-      "type": "documentation",
-      "description": "Adds payments functionality in your Fliplet apps using Stripe and our easy-to-use JS API.",
-      "url": "https://developers.fliplet.com/API/fliplet-payments.html",
-      "sha256": "0756f969f95a98717ec450caa2e1357c1afbd4bb4aa5fd77f3568d7a3f15dc0b"
-    },
-    {
-      "name": "api-fliplet-profile-content",
-      "type": "documentation",
-      "description": "(Returns **`Promise`**)",
-      "url": "https://developers.fliplet.com/API/fliplet-profile-content.html",
-      "sha256": "ed39b7bc0cbe8be92bd3fb8d408ee0f990c793c88120df5588d36122d6c22265"
-    },
-    {
-      "name": "api-fliplet-session",
-      "type": "documentation",
-      "description": "Read, write, and clear the current user session — including cached offline sessions — for authentication state in Fliplet apps.",
-      "url": "https://developers.fliplet.com/API/fliplet-session.html",
-      "sha256": "93f710fd24a5351dc79c70eccdfa1a1103ea2654eba3fd875bc798cb1bb55c4a"
-    },
-    {
-      "name": "api-fliplet-table",
-      "type": "documentation",
-      "description": "Fliplet.UI.Table is a powerful and flexible table component that provides features like sorting, searching, pagination, row selection, expandable rows, and cus…",
-      "url": "https://developers.fliplet.com/API/fliplet-table.html",
-      "sha256": "fab2d654fffb9ee9b13d647132e8cdf56898d07d4c1545a33f39c7e2a8b28784"
-    },
-    {
-      "name": "api-fliplet-themes",
-      "type": "documentation",
-      "description": "Read the list of available app themes and access the current theme's settings and widget-instance values at runtime.",
-      "url": "https://developers.fliplet.com/API/fliplet-themes.html",
-      "sha256": "c4440b08013359dc2f7148562f546698195560a2f310f8baab33e4216ee933b4"
-    },
-    {
-      "name": "api-fliplet-ui-actions",
-      "type": "documentation",
-      "description": "(Returns **`Promise`**)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-actions.html",
-      "sha256": "94e1812e01b252b893d38a3e9719ec9e7b48fd25b1eac21f702c9c4ab836bd9c"
-    },
-    {
-      "name": "api-fliplet-ui-address",
-      "type": "documentation",
-      "description": "The Address field is a customizable component that integrates with Google Maps to enable address lookup. It allows users to search and select addresses using G…",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-address.html",
-      "sha256": "10841a3b17d8bff04b410c38bcf9ad9569f6fc70f0e9178ca9c6c1865a4e7241"
-    },
-    {
-      "name": "api-fliplet-ui-datepicker",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-datepicker.html",
-      "sha256": "45fd463add082bbb394948be733391c997cf31eba910673c45f1b7f94b0852c9"
-    },
-    {
-      "name": "api-fliplet-ui-daterange",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-daterange.html",
-      "sha256": "85ff7cc7a3c3ed612e41c49bfc91d667a8f5bb884f1fd60b140dc4fa0df11fd3"
-    },
-    {
-      "name": "api-fliplet-ui-number",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-number.html",
-      "sha256": "9d20767373bb88161d116d623c12d3feed105b253c8b92327064a3375901ad6b"
-    },
-    {
-      "name": "api-fliplet-ui-panzoom",
-      "type": "documentation",
-      "description": "These public JS APIs will be automatically available in your screen once an Interactive graphics component is dropped into a screen. You can also add the depen…",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-panzoom.html",
-      "sha256": "c5583d707c80b063bbfc8c15c69aa9943f184ff7af495c681f94efd604ad8d2e"
-    },
-    {
-      "name": "api-fliplet-ui-rangeslider",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-rangeslider.html",
-      "sha256": "4d4f4814d9a01dd9f0c597818e649a99b540fe64299ccf6ac7d6a6c9c4ac9cf2"
-    },
-    {
-      "name": "api-fliplet-ui-timepicker",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-timepicker.html",
-      "sha256": "8c6a87e575a7da516c181ef9ccf08781080ed9b4c6c6e02fa7dd914232b0d674"
-    },
-    {
-      "name": "api-fliplet-ui-timerange",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-timerange.html",
-      "sha256": "9b280f9c89970a7b4dffff9a1a297084bc8483fbb82cb696dafa5b0cfe283296"
-    },
-    {
-      "name": "api-fliplet-ui-toast-error",
-      "type": "documentation",
-      "description": "(Returns **`undefined`**)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-toast-error.html",
-      "sha256": "4d9eedba7245be26f3fc0d2ef246b520049396e5769665ce094c4ba84111c978"
-    },
-    {
-      "name": "api-fliplet-ui-toast",
-      "type": "documentation",
-      "description": "(Returns **`Promise`**)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-toast.html",
-      "sha256": "c48eb7f1fc721e75a3aa5fc74d1faf2b543cc646e375851752105d8d9d8ebe0f"
-    },
-    {
-      "name": "api-fliplet-ui-typeahead",
-      "type": "documentation",
-      "description": "(Returns `Object`)",
-      "url": "https://developers.fliplet.com/API/fliplet-ui-typeahead.html",
-      "sha256": "84e0c530855c2b05a80a176667dd18c6bfc902e3a2e8c64dd9ec49516c10739d"
-    },
-    {
-      "name": "api-fliplet-ui",
-      "type": "documentation",
-      "description": "The `Fliplet.UI` namespace contains several classes for creating UI managed by Fliplet. Where appropriate, the UI would come with the following benefits:",
-      "url": "https://developers.fliplet.com/API/fliplet-ui.html",
-      "sha256": "52d01c496ba3518ebf24d9130a34392c37b64945f35a5836eab0441c7c9eed8a"
-    },
-    {
-      "name": "api-helpers-components",
-      "type": "documentation",
-      "description": "Package a Fliplet Helper as a reusable widget-framework component so it can be installed and dropped into apps like any first-party component.",
-      "url": "https://developers.fliplet.com/API/helpers/components.html",
-      "sha256": "51d1cacb51fa79dec9d001094fb78d1d4cb31e93ebf24bc10c45bdd3b2c79566"
-    },
-    {
-      "name": "api-helpers-dynamic-components",
-      "type": "documentation",
-      "description": "Helpers can be dropped into what we refer as \\\"dynamic components\\\". These include the **Dynamic container** and **List Repeater** components. Such components su…",
-      "url": "https://developers.fliplet.com/API/helpers/dynamic-components.html",
-      "sha256": "9524731a497792bbabc68abfa902820cd7ef8795b4a75fd2c96f97d083a798da"
-    },
-    {
-      "name": "api-helpers-example-decision-tree",
-      "type": "documentation",
-      "description": "Build a decision tree using the Fliplet Helper library.",
-      "url": "https://developers.fliplet.com/API/helpers/example-decision-tree.html",
-      "sha256": "3a4ab46b2e2a9a73d71d95e2ff219d23b021f5b3b3d161b7701922760be54321"
-    },
-    {
-      "name": "api-helpers-example-question",
-      "type": "documentation",
-      "description": "A worked example showing how to build a Helper that presents a multiple-choice question and reveals whether the selected answer is correct.",
-      "url": "https://developers.fliplet.com/API/helpers/example-question.html",
-      "sha256": "d99fbd6ad478f9cd5be87f757a99c1be3eddb827f43c6b6445123388b90cfb5c"
-    },
-    {
-      "name": "api-helpers-fields",
-      "type": "documentation",
-      "description": "Pass attributes to a Helper via the HTML `field` element and read them inside the Helper via `this.fields.<name>`.",
-      "url": "https://developers.fliplet.com/API/helpers/fields.html",
-      "sha256": "5fd6907b5272d2191eaf45a85f24cd455c13ca4917e5bee72cebab30107c7423"
-    },
-    {
-      "name": "api-helpers-hooks",
-      "type": "documentation",
-      "description": "Run code at key points in a Helper's lifecycle using the `beforeReady` and `ready` render hooks.",
-      "url": "https://developers.fliplet.com/API/helpers/hooks.html",
-      "sha256": "913fdfd9f2225886f5c913bc372aba2fc570fb71b2b4d94f1e884e5950259952"
-    },
-    {
-      "name": "api-helpers-interface-fields",
-      "type": "documentation",
-      "description": "Define the fields shown in a Helper's Fliplet Studio configuration interface, including their type, label, validation, and default value.",
-      "url": "https://developers.fliplet.com/API/helpers/interface-fields.html",
-      "sha256": "41d4e971cdbb975f8455d12e2ea995df408065363c08727d0d2f330122b776ec"
-    },
-    {
-      "name": "api-helpers-interface-hooks",
-      "type": "documentation",
-      "description": "Run code when a Helper's configuration interface initializes, becomes ready, or is about to save.",
-      "url": "https://developers.fliplet.com/API/helpers/interface-hooks.html",
-      "sha256": "230a3becc92f8459660be22c8f96ab9b89fd4ef4eb641049c7c5677b2cd0b614"
-    },
-    {
-      "name": "api-helpers-interface-libraries",
-      "type": "documentation",
-      "description": "Include [Fliplet-approved](/Fliplet-approved-libraries.html) or third-party JavaScript and CSS libraries in a Helper's configuration interface via the `depende…",
-      "url": "https://developers.fliplet.com/API/helpers/interface-libraries.html",
-      "sha256": "698d4841328394b27be5e7880d6287766eefc23219a88991dca25af5071683a4"
-    },
-    {
-      "name": "api-helpers-interface-methods",
-      "type": "documentation",
-      "description": "Use `find`, `findOne`, and `children` inside a Helper's configuration interface to access nested child Helper instances.",
-      "url": "https://developers.fliplet.com/API/helpers/interface-methods.html",
-      "sha256": "c562f36ab9389e7f94aff26157421a70ea6cddb752aa4e8eaa4dd4554fda322b"
-    },
-    {
-      "name": "api-helpers-interface",
-      "type": "documentation",
-      "description": "Define a configuration UI for your Helper so users can set field values for each instance from within Fliplet Studio.",
-      "url": "https://developers.fliplet.com/API/helpers/interface.html",
-      "sha256": "4a7f95391901616b4bed8814fe7090a88a47cb7113ef4b76b3ef51f6533bb481"
-    },
-    {
-      "name": "api-helpers-libraries",
-      "type": "documentation",
-      "description": "Declare a Helper's runtime dependencies by listing [Fliplet-approved](/Fliplet-approved-libraries.html) or third-party JS/CSS libraries in its `render.dependen…",
-      "url": "https://developers.fliplet.com/API/helpers/libraries.html",
-      "sha256": "a9cadbaf3a1cbd5badf5a032d828bf018e6666f4b21273b32b8430e483d1c7a6"
-    },
-    {
-      "name": "api-helpers-methods",
-      "type": "documentation",
-      "description": "Define instance methods on a Helper and call Helper class methods such as `find` and `findOne` anywhere in the app lifecycle.",
-      "url": "https://developers.fliplet.com/API/helpers/methods.html",
-      "sha256": "ea21d9f2c39675a3275f6d1e87adf991ed62b2b1b396ddfc1de12884eef5c352"
-    },
-    {
-      "name": "api-helpers-overview",
-      "type": "documentation",
-      "description": "Helpers are a UI framework for building custom components in Fliplet apps using JavaScript, with a configuration interface in Fliplet Studio.",
-      "url": "https://developers.fliplet.com/API/helpers/overview.html",
-      "sha256": "2649783e632531697cfaebfdc74fd065e563335b76376ac4f6d87331489f2b00"
-    },
-    {
-      "name": "api-helpers-quickstart",
-      "type": "documentation",
-      "description": "Create your first Fliplet Helper by defining its name, template, and configuration object in screen or global JavaScript.",
-      "url": "https://developers.fliplet.com/API/helpers/quickstart.html",
-      "sha256": "e56e5313485fbb70209877350722c7f03fe95afa56494dd66243cafad6897265"
-    },
-    {
-      "name": "api-helpers-references-constructor",
-      "type": "documentation",
-      "description": "Reference for `Fliplet.Helper()`: the constructor used to define a new Helper in a screen or globally across an app.",
-      "url": "https://developers.fliplet.com/API/helpers/references/constructor.html",
-      "sha256": "b232d12f5bfab75fc557c6551770afdbef34247ac59c486476dad49e00b3bf68"
-    },
-    {
-      "name": "api-helpers-references-fields",
-      "type": "documentation",
-      "description": "Reference for `Fliplet.Helper.field()`: call this from a Helper's configuration interface to read or write the value of another field.",
-      "url": "https://developers.fliplet.com/API/helpers/references/fields.html",
-      "sha256": "0d446f01d1e1a3216f5ca1e0eb34a6bd5fb2f635bd94fe32e3ccd53dcb9db4db"
-    },
-    {
-      "name": "api-helpers-references-query",
-      "type": "documentation",
-      "description": "Reference for `Fliplet.Helper` query methods used to find Helper instances on the current screen from app code or from a configuration interface.",
-      "url": "https://developers.fliplet.com/API/helpers/references/query.html",
-      "sha256": "4eeb98f2c90cd14674ba35aa80b8f67d01417b84eb7c5f2221c8230f8e103046"
-    },
-    {
-      "name": "api-helpers-style",
-      "type": "documentation",
-      "description": "Style a Helper using standard `class` and `style` HTML attributes — they are passed through to the rendered element rather than treated as Helper fields.",
-      "url": "https://developers.fliplet.com/API/helpers/style.html",
-      "sha256": "9b3685f3e2fab73e6c12fb3ed43a710c105829f5e9545df875120dadddf16c1f"
-    },
-    {
-      "name": "api-helpers-templates",
-      "type": "documentation",
-      "description": "Every Helper defines an HTML template that renders it on screen, with support for variable binding, conditional blocks, and loops.",
-      "url": "https://developers.fliplet.com/API/helpers/templates.html",
-      "sha256": "ac63092cc0be477b6e6be79346b04043b9263ea437b8ca53fd35906445915729"
-    },
-    {
-      "name": "api-helpers-views",
-      "type": "documentation",
-      "description": "Define named rich-content views inside a Helper so app builders can drop approved child Helpers into specific regions of its layout.",
-      "url": "https://developers.fliplet.com/API/helpers/views.html",
-      "sha256": "bb3c2388f1e052790f6335091b2cb8e838f500aeece3d0950617c5903fc89f47"
-    },
-    {
-      "name": "api-integrations-sso-saml2",
-      "type": "documentation",
-      "description": "Add enterprise SSO to a Fliplet app with the SAML2 component, using an identity provider metadata XML exchange.",
-      "url": "https://developers.fliplet.com/API/integrations/sso-saml2.html",
-      "sha256": "24e3eb01e5ee32cecb666291dbc1c74fc0248932754b5ff1d5b3602a3de1b166"
-    },
-    {
-      "name": "api-libraries-handlebars",
-      "type": "documentation",
-      "description": "All screens of your Fliplet app already include [Handlebars `2.15.2`](https://handlebarsjs.com/) hence you can start using it straight away. Here's a quick exa…",
-      "url": "https://developers.fliplet.com/API/libraries/handlebars.html",
-      "sha256": "b34a3a4f89446ca5c826921816a75e2d93e4250c38fb3c4626183daa60855c7f"
-    },
-    {
-      "name": "api-like-buttons",
-      "type": "documentation",
-      "description": "Embed a one-tap like button on any screen element, backed by a Data Source that records likes per content ID.",
-      "url": "https://developers.fliplet.com/API/like-buttons.html",
-      "sha256": "5ce1432d890707db0e5fcd0880e7b24905e7058a0f3f40c6db6ff9e2d2269244"
-    },
-    {
-      "name": "api-providers-data-source",
-      "type": "documentation",
-      "description": "The Data Source provider lets users pick or create a data source for a component, including default columns, entries, and access rules.",
-      "url": "https://developers.fliplet.com/API/providers/data-source.html",
-      "sha256": "000ed7bc5d921e46d46966c5570d74ca8160b749093cc8d4f9506a2e18aab68e"
-    },
-    {
-      "name": "api-providers-email",
-      "type": "documentation",
-      "description": "The Email provider lets users compose and configure an email template (subject, body, recipients, headers) that can then be sent via `Fliplet.Communicate.sendE…",
-      "url": "https://developers.fliplet.com/API/providers/email.html",
-      "sha256": "ada2aea6a165793ee5c80f328e09370ba3637f89e8c5b851845013c02f91b082"
-    },
-    {
-      "name": "api-providers-file-picker",
-      "type": "documentation",
-      "description": "The File Picker provider lets users select one or more files from Fliplet's File Manager, optionally scoped by file type or restricted to single-select.",
-      "url": "https://developers.fliplet.com/API/providers/file-picker.html",
-      "sha256": "30027aa1a051d49406f76c46b8e7e7fa87ec34d3aa9e31b2b052274471002ba8"
-    },
-    {
-      "name": "api-providers-link-action",
-      "type": "documentation",
-      "description": "The Link Action provider offers a reusable UI for configuring an action (e.g. navigate to screen, open URL, send email) that another feature will trigger on a…",
-      "url": "https://developers.fliplet.com/API/providers/link-action.html",
-      "sha256": "cb7c454c12e3604ac868940d280954686c063390f9eb8db9021a44322a470c01"
-    },
-    {
-      "name": "app-security",
-      "type": "documentation",
-      "description": "Fliplet apps can have each of their screens and data sources secured so that they can only be accessed when certain conditions are met. Take the following exam…",
-      "url": "https://developers.fliplet.com/App-security.html",
-      "sha256": "0e00fcfefde07d71c8523be09ad90c3b2c6bba188585c996820026de3fafaabe"
-    },
-    {
-      "name": "approved-libraries",
-      "type": "documentation",
-      "description": "The JavaScript libraries Fliplet pre-approves for app development, why you should prefer them over custom ones, and when to reach for each.",
-      "url": "https://developers.fliplet.com/approved-libraries.html",
-      "sha256": "e4fb736cff4fc3187fcb0dbcdda769d1a4061d5868b3485098d09a0d102813bb"
-    },
-    {
-      "name": "async-await",
-      "type": "documentation",
-      "description": "As you might know most of Fliplet JS APIs use **Promises** when the result of such operation cannot be read synchronously. For example when reading data from t…",
-      "url": "https://developers.fliplet.com/Async-await.html",
-      "sha256": "6a0977cd383d98b37528f61aede87008a001f7eefd27bfcf10f9960266dbd1fd"
-    },
-    {
-      "name": "best-practises",
-      "type": "documentation",
-      "description": "Got stuck building components or found some nasty bugs? Here's a few tips that might help you dealing with basic issues during the development of components on…",
-      "url": "https://developers.fliplet.com/Best-practises.html",
-      "sha256": "63e9c7eb3952dae008acfcbc2f0c09dfc2e93524e27a57955b008b2cce601f89"
-    },
-    {
-      "name": "building-components",
-      "type": "documentation",
-      "description": "How to scaffold, run, and develop a Fliplet component locally using the CLI, including the generated file layout and the local dev server.",
-      "url": "https://developers.fliplet.com/Building-components.html",
-      "sha256": "2b29e28ebc5c3f77dcc416728e078def5b650628f2f27abc83580c383d355930"
-    },
-    {
-      "name": "building-functions",
-      "type": "documentation",
-      "description": "How to scaffold and develop an app action function with the CLI, declare its dependencies, and configure it via widget.json.",
-      "url": "https://developers.fliplet.com/Building-functions.html",
-      "sha256": "0c70393f8f20f3750914b9d2570568d60244e3e65115240dd73fe1a326a338b1"
-    },
-    {
-      "name": "building-menus",
-      "type": "documentation",
-      "description": "How to scaffold a Fliplet menu widget, configure its position and settings via menu.json, and develop its template and assets.",
-      "url": "https://developers.fliplet.com/Building-menus.html",
-      "sha256": "0a6103246209d06095494d1bce00fc39c6876896bf1673720207efc45c78a2c1"
-    },
-    {
-      "name": "building-themes",
-      "type": "documentation",
-      "description": "How to scaffold a Fliplet theme, configure its customizable settings from Studio, and preview sample HTML during local development.",
-      "url": "https://developers.fliplet.com/Building-themes.html",
-      "sha256": "b3edced09ed3cf17a15444baa4ef2b14222bc328c275f66cf5a4de321bc4d636"
-    },
-    {
-      "name": "changelog",
-      "type": "documentation",
-      "description": "Changelog notes giving a summary of recent significant changes to the documentation.",
-      "url": "https://developers.fliplet.com/Changelog.html",
-      "sha256": "1a84b6ab79eb794136744dbe251f430f5dd5dcb0b773cd790e3b43cf2eb31c66"
-    },
-    {
-      "name": "cloning-widgets",
-      "type": "documentation",
-      "description": "How to use the fliplet clone and fliplet list CLI commands to download the source of a published component, menu, or theme to your machine.",
-      "url": "https://developers.fliplet.com/Cloning-widgets.html",
-      "sha256": "ea45d0a61509956a4f0e464fce4a67af12fddebee9ae894114dc7a6d2cbaf9f1"
-    },
-    {
-      "name": "code-api-patterns",
-      "type": "documentation",
-      "description": "Overview of the main Fliplet JS API categories (Data Sources, Users, Media, Navigation) and when to pick each one.",
-      "url": "https://developers.fliplet.com/code-api-patterns.html",
-      "sha256": "9986bdeb120972e8f0cbeb0a6a5d572ba2778505fbb7a1234944f6cdf3ac5e28"
-    },
-    {
-      "name": "coding-standards",
-      "type": "documentation",
-      "description": "Coding and documentation standards used across Fliplet APIs, components, and examples, so both humans and AI tools produce consistent Fliplet code.",
-      "url": "https://developers.fliplet.com/coding-standards.html",
-      "sha256": "6cfa7e4471b09c15e21df1da0a075b03d4cbadd7c08cf1c79083741b4af9e46c"
-    },
-    {
-      "name": "component-events",
-      "type": "documentation",
-      "description": "When components are moved around the page in *Edit* mode, Fliplet provides a set of events to manage the user interaction.",
-      "url": "https://developers.fliplet.com/Component-events.html",
-      "sha256": "30457b5e8cf6cf90b5407d9cbb48180d8a8c51ceb642500aeb9816ddc7563efa"
-    },
-    {
-      "name": "components-build-output",
-      "type": "documentation",
-      "description": "Components generally output HTML code when dropped into the page. Their output is compiled with [Handlebars](http://handlebarsjs.com/) using the `build.html` f…",
-      "url": "https://developers.fliplet.com/components/Build-output.html",
-      "sha256": "aa2535ee2a458dc04004951e18b70b244138dcbb0013ae0c2a5ba27d610b7e41"
-    },
-    {
-      "name": "components-definition",
-      "type": "documentation",
-      "description": "The `widget.json` file defines your component as well as the **dependencies** and **assets** it needs in order to run.",
-      "url": "https://developers.fliplet.com/components/Definition.html",
-      "sha256": "49ba33ac3dcc865760ba395268d0f7f54a05e7b016524fbc0deaf119384b21e5"
-    },
-    {
-      "name": "components-interface",
-      "type": "documentation",
-      "description": "Components usually define interfaces to let their instances **save settings**.",
-      "url": "https://developers.fliplet.com/components/Interface.html",
-      "sha256": "32f75d4871146792867009bb9167a7824a601e15f10f0ddf951e165f4d1a984f"
-    },
-    {
-      "name": "components-using-providers",
-      "type": "documentation",
-      "description": "Components can display providers to get specific data from the system or need a particular piece of functionality to be added.",
-      "url": "https://developers.fliplet.com/components/Using-Providers.html",
-      "sha256": "69e736634e99022fc810dc9e53c1856330dd72def0d54a55a8af7cc3baf437f6"
-    },
-    {
-      "name": "context-targeting",
-      "type": "documentation",
-      "description": "Fliplet uses [Modernizr](https://modernizr.com/) (`v3.5.0`) to help developers target users with specific device capabilities and contexts. This lets you targe…",
-      "url": "https://developers.fliplet.com/Context-targeting.html",
-      "sha256": "9cc824712e1f37365e541ca321f226463c83682ce190bb9d4d04e9f875b856b6"
-    },
-    {
-      "name": "custom-headers",
-      "type": "documentation",
-      "description": "Fliplet allows you to set custom headers for your apps. This feature is useful for enhancing security, controlling resource loading, and adding custom HTTP hea…",
-      "url": "https://developers.fliplet.com/Custom-Headers.html",
-      "sha256": "9ddd9b5df20ba7734d68e457cce717d0eac7bd1c740789142e42433b082fcfee"
-    },
-    {
-      "name": "custom-template-for-components",
-      "type": "documentation",
-      "description": "How to override a component's default template with custom HTML and Handlebars in the new container-based drag-and-drop system.",
-      "url": "https://developers.fliplet.com/Custom-template-for-components.html",
-      "sha256": "fb8ef3f1f48a10db209c34d57ef5cc5586ee32b698677985f63562a65ee98417"
-    },
-    {
-      "name": "data-flow",
-      "type": "documentation",
-      "description": "Architecture diagram showing how data flows between Fliplet Studio, Fliplet servers, app clients, and connected data sources.",
-      "url": "https://developers.fliplet.com/Data-flow.html",
-      "sha256": "8b13a7e0552b31138db1b584786c6d608ced17977716be0b5a092da522c28f05"
-    },
-    {
-      "name": "data-integration-service",
-      "type": "documentation",
-      "description": "Fliplet Agent (Data integration service) is a command line utility to synchronize data to and from Fliplet Servers.",
-      "url": "https://developers.fliplet.com/Data-integration-service.html",
-      "sha256": "1f6b5332c4221bcfb25331280780a8622760af6ee00b1e7ecccfaa4fe7825cf0"
-    },
-    {
-      "name": "data-source-hooks",
-      "type": "documentation",
-      "description": "Data Source hooks allow your app's backend to perform certain operations such as **sending emails** or **push notifications** when certain conditions occur, e.…",
-      "url": "https://developers.fliplet.com/Data-Source-Hooks.html",
-      "sha256": "4d4457a08ffeece8d45bd254fc4bc6ee03f71cfa4f1b18310e8597488fb99249"
-    },
-    {
-      "name": "data-source-security",
-      "type": "documentation",
-      "description": "Secure your Data Sources with access rules, data requirements, and custom JavaScript security rules.",
-      "url": "https://developers.fliplet.com/Data-source-security.html",
-      "sha256": "261042acb3afe2c29ada2ae773ff581cab00cdd283678e4625bf616cd66bdf7e"
-    },
-    {
-      "name": "dependencies-and-assets",
-      "type": "documentation",
-      "description": "Both **components** and **themes** can specify a list of dependencies and local assets which should be used when rendering it.",
-      "url": "https://developers.fliplet.com/Dependencies-and-assets.html",
-      "sha256": "56af7be6350037eceab05bf2c7ccbdc9b51f92b4538b485d4b4436e9c920ddcc"
-    },
-    {
-      "name": "event-emitter",
-      "type": "documentation",
-      "description": "Components interfaces can send events to Fliplet Studio using a event emitter bus provided with the `fliplet-core` dependency.",
-      "url": "https://developers.fliplet.com/Event-emitter.html",
-      "sha256": "fa28bc9d4b75446c9b25e5f79bc5e53385386b4a577a309a245974d250b64b20"
-    },
-    {
-      "name": "execution-flow",
-      "type": "documentation",
-      "description": "The rendering and hook lifecycle Fliplet apps go through before a screen is shown to the user, and where to safely run custom code within it.",
-      "url": "https://developers.fliplet.com/Execution-flow.html",
-      "sha256": "f5ed125086e3e89fa8ebc4beef063ecb7578e82f6d95e438accceccbc3cd31fc"
-    },
-    {
-      "name": "file-security",
-      "type": "documentation",
-      "description": "Secure files and folders in your Fliplet apps with access rules and custom JavaScript security rules.",
-      "url": "https://developers.fliplet.com/File-security.html",
-      "sha256": "1249e5fa1b8b0733b538056716d6188b103ad605dd037cc1e4d0baee27d50255"
-    },
-    {
-      "name": "fliplet-approved-libraries",
-      "type": "documentation",
-      "description": "Reference list of every JavaScript library Fliplet pre-approves in apps, including versions and optional add-on libraries.",
-      "url": "https://developers.fliplet.com/Fliplet-approved-libraries.html",
-      "sha256": "19e14c8ecbd5b6743cf1d4f63381c3b589d537f2c15ffedcc035ceb535eecb8e"
-    },
-    {
-      "name": "fliplet-sdk",
-      "type": "documentation",
-      "description": "The Fliplet SDK enables you to use all the JS APIs outside of our environment. This means you can use them on any client-side code which is not sitting on Flip…",
-      "url": "https://developers.fliplet.com/Fliplet-SDK.html",
-      "sha256": "cc91bf5a791145950f1ac5282c37689e9b7b32b9c3822163feef8f1e7de44937"
-    },
-    {
-      "name": "integrate-with-external-api",
-      "type": "documentation",
-      "description": "Call third-party REST APIs from a Fliplet app using jQuery AJAX helpers, including CORS considerations.",
-      "url": "https://developers.fliplet.com/Integrate-with-external-API.html",
-      "sha256": "ef5e9728ac17fd122aabc11b23f9c286fc13af7100a704fe4fc4c575688129f1"
-    },
-    {
-      "name": "introduction",
-      "type": "documentation",
-      "description": "Overview of the Fliplet developer stack (JavaScript, SASS, Handlebars) and the kinds of apps, components, themes, and menus you can build on it.",
-      "url": "https://developers.fliplet.com/Introduction.html",
-      "sha256": "4090751558e81bdc5987c4a7ab5e6db515d66fb129934c8152c00bc30ffc8c2b"
-    },
-    {
-      "name": "javascript-coding-standards",
-      "type": "documentation",
-      "description": "Recommended ES6+ patterns for new Fliplet code and ES5 patterns for legacy apps, covering promises, async/await, and API integration.",
-      "url": "https://developers.fliplet.com/javascript-coding-standards.html",
-      "sha256": "5cb9fc07f88a912d099bd6ca409fb458200e9c73b36567cd87a25d653223cf56"
-    },
-    {
-      "name": "js-apis",
-      "type": "documentation",
-      "description": "How the Fliplet JS APIs (SDK, not a framework) let you interact with data, screens, users, and components from Studio custom code, themes, and widgets.",
-      "url": "https://developers.fliplet.com/JS-APIs.html",
-      "sha256": "407035bc2b0123b1a7352cd8bf6f35b92951c921410a2d4b8402e1d62aefe1fc"
-    },
-    {
-      "name": "native-framework-changelog",
-      "type": "documentation",
-      "description": "Release notes for the Fliplet iOS and Android native frameworks — rebuild your app against a newer version to unlock new features.",
-      "url": "https://developers.fliplet.com/Native-framework-changelog.html",
-      "sha256": "babc4285071bb14aeb09346ed70809dd6ae1027575783217115faa141bbfb8d1"
-    },
-    {
-      "name": "open-source",
-      "type": "documentation",
-      "description": "Where to find Fliplet's open-source code, pre-built app solutions, screen templates, community code examples, and developer documentation.",
-      "url": "https://developers.fliplet.com/open-source.html",
-      "sha256": "626d0021d84d06753f8e6662cb5b7fff5b4a011969e6487485b5c80dd3f12bd7"
-    },
-    {
-      "name": "organization-audit-log-types",
-      "type": "documentation",
-      "description": "Reference table of every audit log type emitted for Fliplet organizations, queryable via the JS or REST API.",
-      "url": "https://developers.fliplet.com/Organization-audit-log-types.html",
-      "sha256": "f40a6ca3de3efaecf6e12465318e11acf4e94e91e9b1b26f51493c3cc918845c"
-    },
-    {
-      "name": "platform-android",
-      "type": "documentation",
-      "description": "How to detect Android at runtime and enable the hardware back button inside a Fliplet app.",
-      "url": "https://developers.fliplet.com/Platform-Android.html",
-      "sha256": "5f29041a4de75531fdb8f9e03f6cffb041f5d867d16033d356daba86f8626640"
-    },
-    {
-      "name": "platform-ios",
-      "type": "documentation",
-      "description": "How to detect iOS at runtime and supply a manual P12 certificate when using Fliplet's Automated App Build with an Apple Enterprise account.",
-      "url": "https://developers.fliplet.com/Platform-iOS.html",
-      "sha256": "f9cecfcaeea9f1ed4c5002b11bfa97ffd3f13db7927acab5dba1b251e887689c"
-    },
-    {
-      "name": "publishing",
-      "type": "documentation",
-      "description": "How to publish Fliplet components, themes, and menus to the Fliplet platform using the CLI's publish command.",
-      "url": "https://developers.fliplet.com/Publishing.html",
-      "sha256": "892b82f708e632a72aa5febbb4205a49af2b9142ef4c8a5a36f3d7e7042fd378"
-    },
-    {
-      "name": "quickstart",
-      "type": "documentation",
-      "description": "Install Node.js and the Fliplet CLI so you can develop and test components, themes, and menus on your machine.",
-      "url": "https://developers.fliplet.com/Quickstart.html",
-      "sha256": "7daa11ac2a8d24a7a026dcd455b4d24feb9baaaf8166dca1ea4c0cbb3c1dc0c2"
-    },
-    {
-      "name": "rate-limiting-for-api",
-      "type": "documentation",
-      "description": "If you’re integrating your app or service with Fliplet APIs, you should be mindful in relation to how frequent your requests are hitting our APIs. Our infrastructure is set up to automatically thrott…",
-      "url": "https://developers.fliplet.com/Rate-limiting-for-API.html",
-      "sha256": "e77416bda33830709b7a194ea488ed7ef46d14fc451419598f3313b9376c39f0"
-    },
-    {
-      "name": "reduce-app-bundle-size",
-      "type": "documentation",
-      "description": "Blacklist assets from your Fliplet app bundle to shrink it for App Store and Google Play submission.",
-      "url": "https://developers.fliplet.com/Reduce-app-bundle-size.html",
-      "sha256": "15dc86e33ff3230e6e5677730f994807c51e2981fe4c746e4efdb164f5c45f12"
-    },
-    {
-      "name": "rest-api-documentation",
-      "type": "documentation",
-      "description": "Index of Fliplet REST endpoints for Data Sources, Media, Notifications, Apps, and more — intended for third-party integrations.",
-      "url": "https://developers.fliplet.com/REST-API-Documentation.html",
-      "sha256": "15b20c8f4eff69bead3da9827809c1f333b49b2ae267084ffc53ad924ef0d30a"
-    },
-    {
-      "name": "rest-api-authenticate",
-      "type": "documentation",
-      "description": "All Fliplet REST API requests are made over HTTPS to a regional endpoint (`api.fliplet.com`, `us.api.fliplet.com`, or `ca.api.fliplet.com`) and must include an…",
-      "url": "https://developers.fliplet.com/REST-API/authenticate.html",
-      "sha256": "075a3fda652a2cd1fce5214b776db9eb7dfe0fb486ceb157f9bc30229aa86fd2"
-    },
-    {
-      "name": "rest-api-fliplet-app-analytics",
-      "type": "documentation",
-      "description": "The App Analytics REST API lets you read your app's analytics data.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-app-analytics.html",
-      "sha256": "18e7bb2120f8353017756d92b37ae3f90e79f64a08a4f9bc04c4594bec9ec51f"
-    },
-    {
-      "name": "rest-api-fliplet-app-subscriptions",
-      "type": "documentation",
-      "description": "The App Subscriptions REST API lets you read and manage your app's users subscribed via push notifications.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-app-subscriptions.html",
-      "sha256": "afb39e26d7e5f610a85ee14feaeb600b481f844dc32fc8e8a64b69f2e8fc645a"
-    },
-    {
-      "name": "rest-api-fliplet-apps",
-      "type": "documentation",
-      "description": "The Apps REST API lets external integrations list, read, create, update, and delete Fliplet apps that the auth token has access to.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-apps.html",
-      "sha256": "b2e9a514e980c59becff909a107e45604bd6696912dd70c8655d45c69f57dad5"
-    },
-    {
-      "name": "rest-api-fliplet-communicate",
-      "type": "documentation",
-      "description": "The Communicate REST API lets external integrations send emails and SMS from a Fliplet app, subject to per-account rate limits.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-communicate.html",
-      "sha256": "e50ee396f4ce865a2f794f4b568c346a9da3ce7b3a4c2fa8858c6fc57576d41d"
-    },
-    {
-      "name": "rest-api-fliplet-datasources",
-      "type": "documentation",
-      "description": "The Data Sources REST API lets external integrations read and modify the data sources belonging to a Fliplet app or organization.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-datasources.html",
-      "sha256": "c103f024bd91a2c5bf2f7ee8d9a34354bb6e640509255d72601a84764b508905"
-    },
-    {
-      "name": "rest-api-fliplet-media",
-      "type": "documentation",
-      "description": "The Media REST API lets external integrations upload, list, and manage media files and folders scoped to a Fliplet app or organization.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-media.html",
-      "sha256": "d18985d25bdf016867417ed753f5992dcfc7d4c5019a5e78104e499719268f9c"
-    },
-    {
-      "name": "rest-api-fliplet-notifications",
-      "type": "documentation",
-      "description": "The Notifications REST API lets external integrations create, schedule, and publish in-app and push notifications to Fliplet app users.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-notifications.html",
-      "sha256": "0ed4c4f9afdaeda81e6c1e77a73a5b56c768ba7ffb27a7e76af6f35cfb719670"
-    },
-    {
-      "name": "rest-api-fliplet-organizations",
-      "type": "documentation",
-      "description": "The Organizations REST API lets external integrations read audit logs and manage resources belonging to a Fliplet organization.",
-      "url": "https://developers.fliplet.com/REST-API/fliplet-organizations.html",
-      "sha256": "a33118653818b979596200a9f573b4c58fa707532eb23a59f06b4065b61cf335"
-    },
-    {
-      "name": "testing-components",
-      "type": "documentation",
-      "description": "Run and write tests for a Fliplet component using the CLI's test command, backed by Mocha, Chai, and Puppeteer.",
-      "url": "https://developers.fliplet.com/Testing-components.html",
-      "sha256": "fff7f468bfa0a9eb113ca0fef8e14cd73addde308244bb4f916d97e803711861"
-    },
-    {
-      "name": "theme-settings-in-css",
-      "type": "documentation",
-      "description": "Our theme is built with reusability in mind, therefore we used SCSS variables for all the settings so that you can use them in your custom CSS.",
-      "url": "https://developers.fliplet.com/Theme-Settings-In-CSS.html",
-      "sha256": "54fc442d6839bb5b746bb0902ea3bcd2aea4a82a5899fc7a858770ff4e33f206"
-    },
-    {
-      "name": "theming-appearance",
-      "type": "documentation",
-      "description": "Expose configurable colors, fonts, and other CSS properties in Fliplet Studio's theme settings UI via your component's widget.json.",
-      "url": "https://developers.fliplet.com/Theming-appearance.html",
-      "sha256": "37120376670b7b3b343b31d4d09c3ea2d0da53e6493d446df154ee562052cd04"
-    },
-    {
-      "name": "ui-guidelines-build",
-      "type": "documentation",
-      "description": "Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's user-facing output.",
-      "url": "https://developers.fliplet.com/UI-guidelines-build.html",
-      "sha256": "5fd5c84cd36a31a591b6137d6e0273c3ff9a74881d22dd7c0abb1dc9a5b751fe"
-    },
-    {
-      "name": "ui-guidelines-interface",
-      "type": "documentation",
-      "description": "Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's Studio settings interface.",
-      "url": "https://developers.fliplet.com/UI-guidelines-interface.html",
-      "sha256": "a00b334d47629966a1ee539688f6cb925f7b6afeab9f01e86b29529cab661105"
-    },
-    {
-      "name": "upcoming",
-      "type": "documentation",
-      "description": "Tracker of Fliplet features recently shipped or in beta, linking to their developer documentation.",
-      "url": "https://developers.fliplet.com/Upcoming.html",
-      "sha256": "c09628469d7663f2b16ee0ec70067dd4b0006c1537026e95c853fc8833025ead"
-    },
-    {
-      "name": "urls-and-ip-addresses",
-      "type": "documentation",
-      "description": "Domains and ports that Fliplet Studio, web apps, native apps, and the Data Integration Service need reachable through a corporate firewall.",
-      "url": "https://developers.fliplet.com/URLs-and-IP-Addresses.html",
-      "sha256": "a00fd01e12904d314439ce789070f5ee654f1d005dac2c3d0a8c77401903c9a9"
-    },
-    {
-      "name": "vs-code-extension-setup-usage",
-      "type": "documentation",
-      "description": "Install, authenticate, and use the Fliplet VS Code extension to develop Fliplet apps directly from your editor.",
-      "url": "https://developers.fliplet.com/VS-Code-Extension-Setup-Usage.html",
-      "sha256": "401947611f2aa07a6f372651c6bf9c47dd9056f3afc2840bbfe937501a88b597"
+      "name": "fliplet-data-sources",
+      "title": "Fliplet data sources",
+      "description": "Data sources JavaScript API and security model: query, insert, update, delete records; row-level security; file storage; data-source hooks.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-data-sources/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/API/fliplet-datasources.html",
+      "tags": [
+        "data-sources",
+        "js-api",
+        "security"
+      ],
+      "sha256": "89e97e708da750d25d3fb1150fa960df2ce1ac3bb8ee8ed242b9429f73ff4df4"
+    },
+    {
+      "name": "fliplet-app-actions",
+      "title": "Fliplet App Actions (server-side automations)",
+      "description": "Build server-side automations that run on a schedule or in response to events. Covers App Actions v1, v2, and v3 APIs.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-app-actions/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/API/core/app-actions.html",
+      "tags": [
+        "app-actions",
+        "js-api",
+        "server-side"
+      ],
+      "sha256": "233171c1233976afa1a937a6ee11d25f9cdcc1bd7a7016a1e99e9f9339404d5f"
+    },
+    {
+      "name": "fliplet-helpers-framework",
+      "title": "Fliplet helpers framework",
+      "description": "Build helpers — reusable Vue-based interface components with editable interface fields, hooks, methods, libraries, and templates.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-helpers-framework/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/API/helpers/overview.html",
+      "tags": [
+        "helpers-framework",
+        "components-framework"
+      ],
+      "sha256": "89fdc96793698322137b56a95f65d1a928514499e8cc9113407138c663c7c488"
+    },
+    {
+      "name": "fliplet-rest-api",
+      "title": "Fliplet REST API",
+      "description": "Server-side REST API for managing organizations, apps, users, data sources, files, and screens from your own backend.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-rest-api/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/REST-API-Documentation.html",
+      "tags": [
+        "rest-api",
+        "server-side"
+      ],
+      "sha256": "5dccfe05277178594185a920779bff805cd9d9168e5ea3abae4e460a2dd0aa6a"
+    },
+    {
+      "name": "fliplet-components-framework",
+      "title": "Fliplet components framework",
+      "description": "Build custom components (widgets) that ship inside Fliplet apps: component definitions, lifecycle, events, dependencies, providers, custom templates, testing.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-components-framework/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/Building-components.html",
+      "tags": [
+        "components-framework",
+        "widgets"
+      ],
+      "sha256": "f93c398ed8cc5e45468722a387b94484d679c1fc648cdde25f4e901041712ee4"
+    },
+    {
+      "name": "fliplet-themes-framework",
+      "title": "Fliplet themes framework",
+      "description": "Build custom themes that control app appearance: color palettes, typography, theme settings exposed in the editor, CSS overrides.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-themes-framework/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/Building-themes.html",
+      "tags": [
+        "themes-framework"
+      ],
+      "sha256": "3d38819114996c96b5855c369b1b7bd0e092f0218de756e1b0e428dbd8cbeb5f"
+    },
+    {
+      "name": "fliplet-menus-framework",
+      "title": "Fliplet menus framework",
+      "description": "Build custom menus that ship inside Fliplet apps to navigate between screens.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-menus-framework/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/Building-menus.html",
+      "tags": [
+        "menus-framework"
+      ],
+      "sha256": "382bab2323f49874d5833d44d3135d9171f281e741552cb711e6e12419ce1987"
+    },
+    {
+      "name": "fliplet-app-build-and-publish",
+      "title": "Fliplet app build and publish",
+      "description": "Publish Fliplet apps to iOS, Android, and the web: bundle size, certificates, automated app builds, platform-specific gotchas.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-app-build-and-publish/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/Publishing.html",
+      "tags": [
+        "publish",
+        "platform"
+      ],
+      "sha256": "31c9528d565f2a6106b6a1923f1efd9d8ecc29afd13c34084c4bb1bb4f9dbec7"
+    },
+    {
+      "name": "fliplet-security-and-compliance",
+      "title": "Fliplet security and compliance",
+      "description": "App-level security, IP allowlisting, organization audit logs, privacy controls. (Data-source-level security lives in fliplet-data-sources.)",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-security-and-compliance/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/App-security.html",
+      "tags": [
+        "security",
+        "compliance"
+      ],
+      "sha256": "6033b95c679d6b08ec74485f74beb40dfab32961925396e3227a52a4dde6a038"
+    },
+    {
+      "name": "fliplet-integrations",
+      "title": "Fliplet integrations",
+      "description": "Integrate with external systems: SSO/SAML2, the Data Integration Service, external REST APIs, OAuth2, AJAX cross-domain.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-integrations/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/Data-integration-service.html",
+      "tags": [
+        "integrations",
+        "sso",
+        "oauth"
+      ],
+      "sha256": "4474108e162ad48db664657430d68a17e7c1e75fe6b2e6b836795092f41d0d88"
+    },
+    {
+      "name": "fliplet-js-api",
+      "title": "Fliplet JavaScript API (Fliplet.*)",
+      "description": "The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User, Navigate, Profile, Communicate, Media, Notifications, UI, ...).",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-js-api/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/API-Documentation.html",
+      "tags": [
+        "js-api"
+      ],
+      "sha256": "209f2ae24b0d62f6eca24b1858836c7ae914ed95292613b72a819c09a3016ad7"
+    },
+    {
+      "name": "fliplet-docs-index",
+      "title": "Fliplet developer documentation (fallback index)",
+      "description": "Site-wide index of the Fliplet developer documentation. Use only as a fallback when no other Fliplet skill (js-api, rest-api, data-sources, app-actions, components-framework, helpers-framework, themes-framework, menus-framework, app-build-and-publish, security-and-compliance, integrations) matches your query. Points at /.well-known/llms.txt for full-site discovery.",
+      "url": "https://developers.fliplet.com/.well-known/agent-skills/fliplet-docs-index/SKILL.md",
+      "landingUrl": "https://developers.fliplet.com/",
+      "tags": [
+        "meta",
+        "index",
+        "fallback"
+      ],
+      "sha256": "48bc03845562de99195fd0c28507be8cc62a40b0aea50248fb55a4ea15d6b112"
     }
   ]
 }

--- a/docs/.well-known/api-catalog
+++ b/docs/.well-known/api-catalog
@@ -1461,6 +1461,16 @@
       ]
     },
     {
+      "anchor": "https://developers.fliplet.com/mcp-worker/README.html",
+      "service-doc": [
+        {
+          "href": "https://developers.fliplet.com/mcp-worker/README.html",
+          "type": "text/html",
+          "title": "fliplet-docs-mcp"
+        }
+      ]
+    },
+    {
       "anchor": "https://developers.fliplet.com/Native-framework-changelog.html",
       "service-doc": [
         {

--- a/docs/.well-known/llms-full.txt
+++ b/docs/.well-known/llms-full.txt
@@ -535,7 +535,7 @@ URL: https://developers.fliplet.com/API-Documentation.html
 
 # JS API Documentation
 
-Feeling lost? Head to the [JS APIs](JS-APIs.md) section of the docs to read more about using these packages in your Fliplet apps, components and themes.
+Index of Fliplet's JavaScript APIs (Core, Data Sources, Media, UI, Communicate) for working with apps, screens, users, and components from custom code. See the [JS APIs](JS-APIs.md) section for guidance on using these packages in your Fliplet apps, components, and themes.
 
 <p class="quote">Are you rather looking for our <strong>RESTful APIs</strong> for complex backend integrations? Jump to our <a href="/REST-API-Documentation.html">documentation</a> to read more.</p>
 
@@ -1008,7 +1008,7 @@ URL: https://developers.fliplet.com/API/components/chat.html
 
 # Chat JS APIs
 
-These public JS APIs will be automatically available in your screens once a **Chat layout** component is used. You can also include these by manually adding the `fliplet-chat` dependency to your app.
+Start conversations, list contacts, count unread messages, and customize chat rendering via `Fliplet.Chat` on screens that use the Chat layout component. You can also include these by manually adding the `fliplet-chat` dependency to your app.
 
 ## Access the chat JS API
 
@@ -1455,7 +1455,7 @@ URL: https://developers.fliplet.com/API/components/data-directory.html
 
 # Data Directory JS APIs
 
-These public JS APIs will be automatically available in your screens once a **Data Directory** component is dropped into such screens.
+Hook into the Data Directory component to override its data source, transform entries before render, and run code at key points in the directory lifecycle on screens that include the component.
 
 ## Run a hook before the directory is rendered
 
@@ -1570,7 +1570,7 @@ URL: https://developers.fliplet.com/API/components/dynamic-container.html
 
 # Dynamic Container JS APIs
 
-The dynamic container allows you to dynamically load data from a data source in a screen. It is useful when you want to display a list of records in a screen using the [list repeater](/API/components/list-repeater.html) component.
+Bind a screen region to a data source query via `Fliplet.DynamicContainer` so the component renders a list of entries with bound expressions, typically paired with the [list repeater](/API/components/list-repeater.html) component.
 
 Here's a HTML sample of a dynamic container with a list repeater component rendering a dynamic value from the loaded data source entries:
 
@@ -1806,7 +1806,7 @@ URL: https://developers.fliplet.com/API/components/form-builder.html
 
 # Form JS APIs
 
-The following JS APIs are available in a screen once a **Form** component is dropped into the screen.
+Populate fields, read submitted values, react to validation events, and trigger submit programmatically on screens that contain a Form component, via `Fliplet.FormBuilder`.
 
 ## Edit a data source entry
 
@@ -2382,7 +2382,7 @@ URL: https://developers.fliplet.com/API/components/interactive-graphics.html
 
 # Interactive Graphics JS APIs
 
-These public JS APIs are available in screens where an **Interactive Graphics** component is present.
+Override marker data, preselect a marker or map on render, and respond to label clicks via Interactive Graphics component hooks on screens that use it.
 
 ## Hooks
 
@@ -3476,7 +3476,7 @@ URL: https://developers.fliplet.com/API/components/list-repeater.html
 
 # List Repeater JS APIs
 
-The list repeater component is a container for a list of records. It is used to display a list of records from a data source.
+Render a list of data source entries inside a Dynamic Container via `Fliplet.ListRepeater`, with hooks to modify rows before and after render.
 
 Here's a HTML sample of a list repeater component in a dynamic container rendering a dynamic value from the loaded data source entries:
 
@@ -3596,7 +3596,7 @@ URL: https://developers.fliplet.com/API/components/login.html
 
 # Login
 
-The login component fires hooks at key points in the authentication lifecycle. These allow you to run custom code after a user successfully logs in or when a returning user's session is re-validated.
+Run custom code after a user authenticates or when a returning user's session is re-validated via the Login component's `login` and `sessionValidate` hooks.
 
 ## Hooks
 
@@ -3725,7 +3725,7 @@ URL: https://developers.fliplet.com/API/components/push-notifications.html
 
 # Push Notifications JS APIs
 
-These public JS APIs will be automatically available in your screens once **Push Notifications** have been enabled for your app.
+Prompt users to subscribe to push notifications, read device push settings, fetch the subscription ID and token, and unsubscribe on apps with Push Notifications enabled.
 
 ## Ask the user to subscribe for push notifications
 
@@ -3842,7 +3842,7 @@ URL: https://developers.fliplet.com/API/components/record-container.html
 
 # Record container JS APIs
 
-The record container allows you to display one record from a data source in a screen. It is useful when you want to display a single record in a screen, for example a contact card.
+Render a single data source entry in a screen via `Fliplet.RecordContainer`, with hooks to modify the query and react when data is retrieved — useful for layouts like a contact card.
 
 Here's a HTML sample of a record container with a text component rendering a dynamic value from the loaded data source entry:
 
@@ -3956,7 +3956,7 @@ URL: https://developers.fliplet.com/API/core/ai.html
 
 # `Fliplet.AI`
 
-Build AI features in Fliplet apps with chat, completions, streaming, and task helpers — backed by OpenAI (GPT, o-series) or Google Gemini models via direct proxy.
+Build AI features with `Fliplet.AI` — chat, completions, streaming, image generation, transcription, and embeddings via OpenAI (GPT, o-series) or Google Gemini proxies.
 
 These APIs empower your apps with OpenAI models such as `GPT 3.5` to do things like:
 
@@ -6208,7 +6208,7 @@ URL: https://developers.fliplet.com/API/core/app-actions-v3.html
 
 # App Actions V3
 
-Run a single `execute(context)` JavaScript function on the server or client, either ad hoc or on a schedule.
+Write and run JavaScript code directly on the server or client to perform automations, scheduled tasks, and on-demand operations. Each V3 app action is a single `execute(context)` function that runs ad hoc or on a cron schedule.
 
 ![How it works](/assets/img/app-actions.png)
 
@@ -8556,7 +8556,7 @@ URL: https://developers.fliplet.com/API/core/localization.html
 
 # `Fliplet.Locale`
 
-Localize strings, dates, and numbers in your components to the device or browser language and region.
+Translate strings and format dates and numbers in Fliplet components via `Fliplet.Locale`, the `T()` shorthand, and `translation.json` files using [i18next](https://www.i18next.com/).
 
 There are 3 key aspects of a component that can be localized to the device or browser language/region settings.
 
@@ -8879,7 +8879,7 @@ URL: https://developers.fliplet.com/API/core/modal.html
 
 # `Fliplet.Modal`
 
-Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio, powered by [Bootbox](http://bootboxjs.com/) — see its documentation for the full set of options you can pass.
+Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio via `Fliplet.Modal`, powered by [Bootbox](http://bootboxjs.com/) — see its documentation for the full set of options you can pass.
 
 <p class="info">This JS API is only available in widget interfaces. For adding modals and confirmation windows to Fliplet Apps themselves, use <a href="https://developers.fliplet.com/API/fliplet-ui-actions.html">Fliplet.UI.Actions</a> or <a href="https://developers.fliplet.com/API/fliplet-ui-toast.html">Fliplet.UI.Toast</a> instead.</p>
 
@@ -8912,7 +8912,7 @@ URL: https://developers.fliplet.com/API/core/navigate.html
 
 # `Fliplet.Navigate`
 
-Navigate between app screens, open external URLs, pass query parameters, and handle back, home, and modal navigation.
+Navigate between app screens, open external URLs, pass query parameters, and handle back, home, and modal navigation via `Fliplet.Navigate`.
 
 ## Query parameters
 
@@ -11264,7 +11264,7 @@ URL: https://developers.fliplet.com/API/datasources/query-operators.html
 
 # Data Sources query operators
 
-Reference for MongoDB/Sift-style operators (`$eq`, `$gt`, `$in`, `$regex`, …) usable in `connection.find()` `where` clauses.
+Filter Data Source queries with MongoDB/Sift operators (`$eq`, `$gt`, `$in`, `$regex`, `$and`, `$or`, and others) inside `connection.find()` `where` clauses.
 
 ## MongoDB-style Operators (Sift.js)
 
@@ -11809,6 +11809,8 @@ URL: https://developers.fliplet.com/API/fliplet-barcode.html
 
 # `Fliplet.Barcode`
 
+Scan QR codes and other 1D/2D barcodes from the device camera, and generate barcode images on screen, via the `fliplet-barcode` package. Barcode scanning is only supported in native apps.
+
 ## Install
 
 Add the `fliplet-barcode` dependency to your screen or app resources.
@@ -12337,9 +12339,7 @@ URL: https://developers.fliplet.com/API/fliplet-content.html
 
 # `Fliplet.Content()`
 
-(Returns **`Promise`**)
-
-The `fliplet-content` package contains helpers to create and manage content using data sources.
+Create, query, update, and delete shared content records — bookmarks, likes, saved searches, and similar features — backed by a Fliplet data source via `Fliplet.Content()`. The constructor resolves with an instance whose methods aggregate content created across users, screens, and apps.
 
 When **content** is created using `Fliplet.Content()`, a record is stored in the specified data source. This can be used to aggregate all the content being created via different users, screens and apps.
 
@@ -12499,6 +12499,8 @@ Delete existing entries.
 URL: https://developers.fliplet.com/API/fliplet-csv.html
 
 # `Fliplet.CSV`
+
+Encode and decode CSV in Fliplet apps via the `fliplet-csv` package. The library wraps [Papa Parse](https://www.papaparse.com/) so it accepts JSON, arrays, or explicit fields/data shapes and supports Base64 and `data:` URL output.
 
 ## Install
 
@@ -14449,7 +14451,7 @@ URL: https://developers.fliplet.com/API/fliplet-gamify.html
 
 # `Fliplet.Gamify`
 
-Configure gamification logic for your apps.
+Configure gamification with logs, variables, and achievements via `Fliplet.Gamify`; track points, milestones, and badges backed by a data source per user.
 
 ---
 
@@ -15770,7 +15772,7 @@ URL: https://developers.fliplet.com/API/fliplet-payments.html
 
 <section class="sides no-margin">
   <div>
-    <p>Add Stripe-powered payments and checkout to a Fliplet app with a Data Source of products and a few JS API calls.</p>
+    <p>Accept Stripe payments and checkout in Fliplet apps via <code>Fliplet.Payments</code>, with a products data source and webhook-driven order tracking.</p>
     <p>Before you start, make sure you have signed up for a <a href="https://stripe.com/" target="_blank">Stripe account</a> on their website as it will be required in the very first steps of the integration.</p>
   </div>
   <div>
@@ -16044,9 +16046,7 @@ URL: https://developers.fliplet.com/API/fliplet-profile-content.html
 
 # `Fliplet.Profile.Content()`
 
-(Returns **`Promise`**)
-
-Create, query, update, and delete user-attributed content records in a Data Source, so each user only sees their own entries.
+Create, query, update, and delete user-attributed content records in a data source via `Fliplet.Profile.Content()` so each user only sees, edits, or deletes their own entries. A unique user identifier is automatically attached to every record, with no app login required.
 
 When **content** is created using `Fliplet.Profile.Content()`, a record is stored in the specified data source with the content **attributed to the user**. This means the following:
 
@@ -16371,7 +16371,7 @@ URL: https://developers.fliplet.com/API/fliplet-table.html
 
 # `Fliplet.UI.Table`
 
-Fliplet.UI.Table is a powerful and flexible table component that provides features like sorting, searching, pagination, row selection, expandable rows, and custom rendering capabilities.
+Render searchable, sortable tables with pagination, row selection, expandable rows, and custom cell rendering via `Fliplet.UI.Table`.
 
 ## Install
 
@@ -17347,11 +17347,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-actions.html
 
 # `Fliplet.UI.Actions()`
 
-(Returns **`Promise`**)
-
-Show a sheet of options the user can choose from.
-
-If an action is chosen, the Promise is resolved when the specified action is completed or resolved with the 0-based index provided as the first parameter. The Promise is also resolved when user chooses to cancel and dismiss the action sheet. In this case, the index provided in the resolving function will be `undefined`.
+Show a native-style action sheet with a title, a list of labeled options, and an optional cancel button via `Fliplet.UI.Actions()`. The returned Promise resolves with the 0-based index of the chosen label once its action runs, or with `undefined` if the user cancels.
 
 ## Screenshots
 
@@ -17449,7 +17445,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-address.html
 
 # `Fliplet.UI.AddressField()`
 
-The Address field is a customizable component that integrates with Google Maps to enable address lookup. It allows users to search and select addresses using Google's autocomplete and retrieve location details.
+Add a Google Maps autocomplete address field to a screen via `Fliplet.UI.AddressField()` so users can search, select, and retrieve location details.
 
 ## Install
 
@@ -18065,9 +18061,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-datepicker.html
 
 # `Fliplet.UI.DatePicker()`
 
-(Returns `Object`)
-
-Create a date picker input field. This provides a simple mechanism to allow the selection of a date.
+Render a date picker input field with an optional preset value and a `required` flag via `Fliplet.UI.DatePicker()`. The constructor returns a controller instance with `get`, `set`, and `change` methods to read or update the selected date programmatically.
 
 ## Install
 
@@ -18177,9 +18171,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-daterange.html
 
 # `Fliplet.UI.DateRange()`
 
-(Returns `Object`)
-
-Create a date range input field. This provides a simple mechanism to allow the selection of a date range.
+Render a paired start/end date range input with an optional default `{ start, end }` value in `YYYY-MM-DD` format and a `required` flag via `Fliplet.UI.DateRange()`. The constructor returns a controller instance with `get`, `set`, and `change` methods for reading or updating the selected range.
 
 ## Install
 
@@ -18299,9 +18291,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-number.html
 
 # `Fliplet.UI.NumberInput()`
 
-(Returns `Object`)
-
-Create a number input field. This provides a simple mechanism to allow the input of a number.
+Render a numeric input field that accepts an optional preset value and a `required` flag via `Fliplet.UI.NumberInput()`. The constructor returns a controller instance with `get`, `set`, and `change` methods for reading and updating the user-entered number.
 
 ## Install
 
@@ -18406,8 +18396,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-panzoom.html
 
 # `Fliplet.UI.PanZoom`
 
-These public JS APIs will be automatically available in your screen once an Interactive graphics component is dropped into a screen.
-You can also add the dependency `fliplet-ui-panzoom` in Developer options -> Resources
+Pan, zoom, and place markers on images or interactive graphics via `Fliplet.UI.PanZoom`, with pinch, mouse wheel, and double-tap support. You can also add the dependency `fliplet-ui-panzoom` in Developer options -> Resources to use it outside of an Interactive Graphics component.
 
 ## Create an instance
 `Fliplet.UI.PanZoom.create(selector, options)`
@@ -18569,9 +18558,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-rangeslider.html
 
 # `Fliplet.UI.RangeSlider()`
 
-(Returns `Object`)
-
-Create a range slider input field. This provides a simple mechanism to allow the selection of a number within the given range.
+Render a range slider input bounded by `min`, `max`, and `step` attributes with an optional default value via `Fliplet.UI.RangeSlider()`. The constructor returns a controller instance with `get`, `set`, and `change` methods to read or update the selected number programmatically.
 
 ## Install
 
@@ -18681,9 +18668,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-timepicker.html
 
 # `Fliplet.UI.TimePicker()`
 
-(Returns `Object`)
-
-Create a time picker input field. This provides a simple mechanism to allow the selection of a time.
+Render a time picker input that captures values in 24-hour `HH:mm` format with an optional preset value and a `required` flag via `Fliplet.UI.TimePicker()`. The constructor returns a controller instance with `get`, `set`, and `change` methods for reading or updating the selected time.
 
 ## Install
 
@@ -18792,9 +18777,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-timerange.html
 
 # `Fliplet.UI.TimeRange()`
 
-(Returns `Object`)
-
-Create a time range input field. This provides a simple mechanism to allow the selection of a time range.
+Render a paired start/end time range input in `HH:mm` format with an optional default `{ start, end }` value and a `required` flag via `Fliplet.UI.TimeRange()`. The constructor returns a controller instance with `get`, `set`, and `change` methods for reading or updating the selected range.
 
 ## Install
 
@@ -18914,10 +18897,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-toast-error.html
 
 # `Fliplet.UI.Toast.error()`
 
-(Returns **`undefined`**)
-
-Parses an error object and shows an optional initial message and a button
-to view the detailed error message that is typically more technical.
+Parse an error object and show a toast with a friendly initial message plus a button that reveals the detailed, more technical error text via `Fliplet.UI.Toast.error()`. Useful for surfacing data source, network, and API failures to end users without exposing raw stack traces by default.
 
 ## Usage
 
@@ -18966,9 +18946,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-toast.html
 
 # `Fliplet.UI.Toast()`
 
-(Returns **`Promise`**)
-
-Create a non-obtrusive toast notification that auto-dismisses, in minimal or regular styling, without blocking the user.
+Show a non-blocking toast notification via `Fliplet.UI.Toast()` — in compact `minimal` or attention-grabbing `regular` styling — with configurable title, message, position, duration, optional progress bar, and call-to-action buttons. The constructor returns a Promise resolving to a toast instance with `dismiss` and `setProgress` controls.
 
 There are 2 different types of Toast notifications, **minimal** and **regular**.
 
@@ -19146,9 +19124,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui-typeahead.html
 
 # `Fliplet.UI.Typeahead()`
 
-(Returns `Object`)
-
-Create a typeahead input that offers real-time suggestions from a predefined list as the user types.
+Render a typeahead input that surfaces real-time suggestions from a predefined `options` list as the user types, with optional `freeInput`, `maxItems`, and `placeholder` settings via `Fliplet.UI.Typeahead()`. The constructor returns a controller instance with `get`, `set`, and `change` methods for reading or updating the selected values.
 
 ## Install
 
@@ -19251,7 +19227,7 @@ URL: https://developers.fliplet.com/API/fliplet-ui.html
 
 # `Fliplet.UI`
 
-The `Fliplet.UI` namespace contains several classes for creating UI managed by Fliplet. Where appropriate, the UI would come with the following benefits:
+The `Fliplet.UI` namespace contains classes for Fliplet-managed UI primitives such as toasts, action sheets, modals, date and time pickers, typeahead, tables, and panzoom. Where appropriate, these UI elements come with the following benefits:
 
   - Optimized usability across all devices/platforms
   - Support for localization incl. RTL language
@@ -19461,7 +19437,7 @@ URL: https://developers.fliplet.com/API/helpers/dynamic-components.html
 
 <p class="warning">This feature is currently available to beta users only.</p>
 
-Helpers can be dropped into what we refer as "dynamic components". These include the **Dynamic container** and **List Repeater** components. Such components supports reactive data binding between the source of the data and the helpers you build.
+Render Helper instances inside Dynamic Container and List Repeater components, with reactive per-record data binding via `supportsDynamicContext`. The two components support reactive data binding between the source of the data and the helpers you build.
 
 To support reactive data communication between the two, you must add the `supportsDynamicContext: true` property to your helper configuration:
 
@@ -20077,6 +20053,7 @@ URL: https://developers.fliplet.com/API/helpers/interface-fields.html
 # Helper configuration interface: fields
 
 Define the fields shown in a Helper's Fliplet Studio configuration interface, including their type, label, validation, and default value.
+
 ## Properties for all fields
 
 The following property can be defined for all field types (except when specified otherwise):
@@ -22198,7 +22175,7 @@ URL: https://developers.fliplet.com/API/libraries/handlebars.html
 
 # Using Handlebars in your apps
 
-All screens of your Fliplet app already include [Handlebars `2.15.2`](https://handlebarsjs.com/) hence you can start using it straight away. Here's a quick example following the official Handlebars docs:
+Use [Handlebars `2.15.2`](https://handlebarsjs.com/) in Fliplet app screens for templating, with built-in helpers for images, dates, auth URLs, JSON, and conditional comparisons. Handlebars is included on every screen, so you can start using it straight away — here's a quick example following the official Handlebars docs:
 
 {% raw %}
 ```js
@@ -22376,6 +22353,32 @@ LikeButton(options)
     * `count` Number of likes
   * `likeWrapper` (String) HTML to use when wrapping the like button. **Default**: `<a class="btn btn-like" href="#"></a>`
   * `likedWrapper` (String) HTML to use when wrapping the liked button. **Default**: `<a class="btn btn-like" href="#"></a>`
+  * `offline` (Boolean) When `true`, taps are accepted even when the device is offline. The underlying data source connector queues the write to its outbox and replays it once the device is back online; the optimistic UI state is preserved across the reconnect. When `false`, the user is shown a "Please connect to the internet" popup instead and the toggle is rejected. Set to `true` for use cases such as bookmarking, where users expect the action to work offline; leave as `false` for like/unlike interactions that are only meaningful while online. **Default**: `false`
+
+## Offline behaviour
+
+By default, `LikeButton` only works while the device is online — tapping the button while offline shows a "Please connect to the internet" popup and the toggle is dropped. This is the right behaviour for likes (where the like count itself is a shared, online concept) but not for per-user toggles such as bookmarks, which users expect to keep working offline.
+
+Pass `offline: true` to opt the button into offline-aware behaviour:
+
+```js
+LikeButton({
+  target: '#bookmark-target',
+  dataSourceId: 12345,
+  view: 'userBookmarks',
+  content: { entryId: '42-bookmark' },
+  likeLabel: '<i class="fa fa-bookmark-o"></i>',
+  likedLabel: '<i class="fa fa-bookmark"></i>',
+  offline: true
+});
+```
+
+When `offline: true`:
+
+* Taps are not blocked while offline. The optimistic state of the button updates immediately.
+* The write goes through the data source connector, which queues the operation in `Fliplet.Storage` if the network call fails.
+* The queue is automatically drained when `Fliplet.Navigator.onOnline()` fires, and on app startup. No additional caller code is required.
+* Read state survives offline relaunches when the data source is bundled for offline use (native mobile only). On platforms without an offline database (e.g. web), reads still require a connection — only writes are queued.
 
 ## Methods
 
@@ -22532,7 +22535,7 @@ URL: https://developers.fliplet.com/API/providers/email.html
 
 # Email provider
 
-The Email provider lets users compose and configure an email template (subject, body, recipients, headers) that can then be sent via `Fliplet.Communicate.sendEmail()`.
+Compose email templates (subject, body, recipients, headers) in a reusable provider UI for sending via `Fliplet.Communicate.sendEmail()`.
 
 **Package**: `com.fliplet.email-provider`
 
@@ -22675,7 +22678,7 @@ URL: https://developers.fliplet.com/API/providers/link-action.html
 
 # Link Action provider
 
-The Link Action provider offers a reusable UI for configuring an action (e.g. navigate to screen, open URL, send email) that another feature will trigger on a condition it defines.
+Configure link actions (navigate to screen, open URL, document, video, or run JS) in a reusable provider UI executable via `Fliplet.Navigate.to()`.
 
 **Package**: `com.fliplet.link`
 
@@ -22751,7 +22754,7 @@ URL: https://developers.fliplet.com/App-security.html
 
 # Securing your apps
 
-Fliplet apps can have each of their screens and data sources secured so that they can only be accessed when certain conditions are met. Take the following example:
+Restrict screen and data-source access in Fliplet apps using login conditions, IP allow/deny lists, and custom JavaScript rules that read session and page context. For example:
 
 > My app has 5 screens, one being a login screen with email validation based on a Fliplet data source. I want to secure the other 4 screens of the app so that they can only be accessed by logged-in users.
 
@@ -23105,7 +23108,7 @@ URL: https://developers.fliplet.com/Async-await.html
 
 # Writing more readable code when using the JS APIs
 
-As you might know most of Fliplet JS APIs use **Promises** when the result of such operation cannot be read synchronously. For example when reading data from the server or the device storage.
+Use `async`/`await` with Fliplet's Promise-based JS APIs for cleaner data-source reads, navigation, hooks, and user-session code, with `try`/`catch` error handling. Most Fliplet JS APIs return **Promises** when the result of an operation cannot be read synchronously, for example when reading data from the server or device storage.
 
 Take the following example:
 
@@ -23169,7 +23172,7 @@ URL: https://developers.fliplet.com/Best-practises.html
 
 # Best practice and advices when building components
 
-Got stuck building components or found some nasty bugs? Here's a few tips that might help you dealing with basic issues during the development of components on our platform.
+Common gotchas when building Fliplet components: instance data, multi-drop handling, Handlebars escaping for Vue/Angular curly braces, and required dependencies.
 
 ## Instance data
 
@@ -25003,7 +25006,7 @@ URL: https://developers.fliplet.com/Component-events.html
 
 # Component events
 
-When components are moved around the page in *Edit* mode, Fliplet provides a set of events to manage the user interaction.
+Listen for component lifecycle events emitted while users edit a Fliplet screen — such as adding, added, removed, moved, and render — via `Fliplet.Hooks.on('componentEvent')`.
 
 ## Usage
 
@@ -25064,7 +25067,7 @@ URL: https://developers.fliplet.com/components/Build-output.html
 
 # Output of components
 
-Components generally output HTML code when dropped into the page. Their output is compiled with [Handlebars](http://handlebarsjs.com/) using the `build.html` file from your component.
+Render Fliplet component output from `build.html` via [Handlebars](http://handlebarsjs.com/), then read per-instance settings with `Fliplet.Widget.instance` and opt into dynamic-container context. Components generally output HTML code when dropped into the page; their output is compiled using the `build.html` file from your component.
 
 App components are not required to output any HTML, though when they do you can decide whether their output will be appended at the beginning or the end of the page (e.g. once the body tag is opened or closed).
 
@@ -25197,7 +25200,7 @@ URL: https://developers.fliplet.com/components/Definition.html
 
 # The component definition file
 
-The `widget.json` file defines your component as well as the **dependencies** and **assets** it needs in order to run.
+Define a Fliplet component in `widget.json`: `name`, `package`, `version`, `icon`, `tags`, `html_tag`, plus `interface` and `build` entries for dependencies and assets. The file declares everything Fliplet needs to load and run your component.
 
 Please note: if you make changes to the `widget.json` file, restart the development server (`fliplet run`) to apply the changes you made.
 
@@ -25349,7 +25352,7 @@ URL: https://developers.fliplet.com/components/Interface.html
 
 # Components interfaces
 
-Components usually define interfaces to let their instances **save settings**.
+Build a Fliplet component's settings UI in `interface.html` with [Handlebars](http://handlebarsjs.com/), persist values via `Fliplet.Widget.save`, and rehydrate them with `Fliplet.Widget.getData` when the interface is reopened.
 
 A quick example is the interface of the [button component](https://github.com/Fliplet/fliplet-widget-primary-button) to let you specify the button label and the action to be fired or page to view once tapped:
 
@@ -25768,7 +25771,7 @@ URL: https://developers.fliplet.com/Custom-Headers.html
 
 # Custom Headers
 
-Fliplet allows you to set custom headers for your apps. This feature is useful for enhancing security, controlling resource loading, and adding custom HTTP headers to your applications.
+Configure custom HTTP response headers (CSP, HSTS, CORS, custom security headers) for a Fliplet app via `Fliplet.App.Settings` and the Developer Options panel. This is useful for enhancing security, controlling resource loading, and adding custom HTTP headers to your applications.
 
 ## Setting up Custom Headers
 
@@ -27248,7 +27251,7 @@ URL: https://developers.fliplet.com/Data-Source-Hooks.html
 
 # Data Source Hooks
 
-Data Source hooks allow your app's backend to perform certain operations such as **sending emails** or **push notifications** when certain conditions occur, e.g. inserting or updating a Data Source Entry.
+Trigger emails, SMS, push notifications, web requests, or column operations on Data Source `insert`, `update`, `beforeSave`, or `beforeQuery` events using [Sift.js](https://github.com/Fliplet/sift.js) match conditions.
 
 **Please note**: hooks do not run when data is inserted or saved via the "App data" section in **Fliplet Studio**.
 
@@ -28193,7 +28196,7 @@ URL: https://developers.fliplet.com/Dependencies-and-assets.html
 
 # Dependencies and assets
 
-Both **components** and **themes** can specify a list of dependencies and local assets which should be used when rendering it.
+Declare package dependencies and bundled JS, CSS, and font assets for Fliplet components and themes, with separate interface and build entries plus `appAssets`.
 
 ---
 
@@ -28367,7 +28370,7 @@ URL: https://developers.fliplet.com/File-security.html
 
 # Securing Fliplet files and folders
 
-How to control read, upload, update, and delete access to media files and folders in Fliplet apps using access rules and custom security rules.
+Secure files and folders in your Fliplet apps with access rules and custom JavaScript security rules that control read, upload, update, and delete access — enforced server-side for all app token requests.
 
 ## Contents
 
@@ -28955,7 +28958,7 @@ URL: https://developers.fliplet.com/Fliplet-SDK.html
 
 # Fliplet SDK
 
-The Fliplet SDK enables you to use all the JS APIs outside of our environment. This means you can use them on any client-side code which is not sitting on Fliplet's domains.
+Load Fliplet JS APIs on any external website by including `sdk.js` with an auth token and an optional comma-separated package list (e.g. `fliplet-media`, `fliplet-datasources`). This lets you call the same JS APIs from client-side code that isn't hosted on Fliplet's domains.
 
 ---
 
@@ -29463,6 +29466,103 @@ When you're ready, move to the next section of the documentation to start buildi
 
 [Build a component →](Building-components.md)
 {: .buttons}
+
+---
+
+# fliplet-docs-mcp
+URL: https://developers.fliplet.com/mcp-worker/README.html
+
+# fliplet-docs-mcp
+
+Cloudflare Worker exposing an MCP (Model Context Protocol) server at **https://developers.fliplet.com/mcp** with `search_fliplet_docs` and `fetch_fliplet_doc` tools backed by `.well-known/llms.txt`.
+
+Any MCP-aware AI client (Claude Code, Cursor, custom OpenAI tools) can add
+this URL as an MCP server and immediately get two tools:
+
+- **`search_fliplet_docs({ query, limit?, tags?, type? })`** — fuzzy search
+  the docs index at `.well-known/llms.txt`, returns ranked matches with
+  title, URL, description, group, and relevance score.
+- **`fetch_fliplet_doc({ url })`** — fetch the raw Markdown of a docs page.
+  Strict URL validation: must be under `developers.fliplet.com` and end in
+  `.md`. No query strings, no fragments. SSRF-safe.
+
+## Architecture
+
+- **Stateless.** Fresh `McpServer` instance per request; no Durable Objects.
+- **Index source.** `search_fliplet_docs` reads `.well-known/llms.txt` from
+  the same origin; caches 60 s in module scope per isolate.
+- **CORS.** `Access-Control-Allow-Origin: *` on all responses and a bare
+  204 for preflight `OPTIONS`. Read-only surface on public docs.
+- **Rate limiting.** Configured via a Cloudflare Ruleset rate-limit rule on
+  the `developers.fliplet.com` zone (not in code). Start with 100 req/min
+  per IP, 429 with `Retry-After`.
+
+## Local development
+
+```bash
+cd docs/mcp-worker
+npm install
+npm run dev          # wrangler dev, local MCP server at http://localhost:8787
+npm test             # vitest — parser, search, SSRF guard
+npm run typecheck    # tsc --noEmit
+```
+
+Smoke test the local server:
+
+```bash
+curl -sX POST http://localhost:8787 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
+
+curl -sX POST http://localhost:8787 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_fliplet_docs","arguments":{"query":"data sources"}}}' | jq
+```
+
+## Pinned dependencies
+
+`@modelcontextprotocol/sdk@1.20.2` + `agents@0.2.21` are pinned **exactly**
+— versions `1.21.0+` of the SDK bundle `ajv@8.17.1`, which relies on
+`new Function()` / `eval()` and cannot run in the Cloudflare Workers
+runtime. See the Phase 0.13 SDK spike notes in the plan file at
+`~/.claude/plans/sites-fliplet-studio-currently-has-a-crystalline-lemon.md`
+for the full write-up.
+
+## Deployment
+
+Via `wrangler deploy` from this directory. Requires the `fliplet.com` zone
+in the Cloudflare account and the route binding in `wrangler.jsonc`.
+
+CI/CD: wire `wrangler deploy` into a GitHub Actions workflow when ready —
+not included in this PR. Must be triggered only on `mcp-worker/**` changes
+on `master`.
+
+## MCP client configuration
+
+Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "fliplet-docs": {
+      "type": "http",
+      "url": "https://developers.fliplet.com/mcp"
+    }
+  }
+}
+```
+
+Cursor, Codex, and other Streamable-HTTP MCP clients take the same
+endpoint URL.
+
+## Naming note
+
+`fliplet-kb` (the Fliplet-internal code-and-docs knowledge base MCP server)
+also historically exposed a tool named `search_fliplet_docs`. To avoid a
+collision when an AI client is configured with both servers, fliplet-kb
+renames its dev-docs-scoped tool to `search_fliplet_dev_docs` (broader
+scope: includes internal docs + source code) while this server keeps the
+short name for the public docs surface.
 
 ---
 
@@ -30196,7 +30296,7 @@ URL: https://developers.fliplet.com/Rate-limiting-for-API.html
 
 # Rate limiting for APIs
 
-If you're integrating your app or service with Fliplet APIs, you should be mindful in relation to how frequent your requests are hitting our APIs.
+Fliplet rate-limits Data Source, Communicate, audit-log, AI, and App Action APIs on a per-user basis. Back off on `429` responses and batch writes via the commit endpoint to stay within limits.
 
 Our infrastructure is set up to automatically throttle down and rate limit requests depending on how frequently they are made.
 
@@ -30233,9 +30333,9 @@ URL: https://developers.fliplet.com/Reduce-app-bundle-size.html
 
 # Reduce your app bundle size
 
-Blacklist assets from your Fliplet app bundle to shrink it for App Store and Google Play submission.
+Exclude assets from your Fliplet app bundle by content type, file extension, or media file ID to shrink it for App Store and Google Play submission.
 
-Navigate to the **App settings** >> **Launch assets** section in Fliplet Studio and you'll find a section for **blacklisting assets**.
+Navigate to the **App settings** >> **Launch assets** section in Fliplet Studio and you'll find a section for excluding assets.
 
 Rules are defined as a JSON array of objects like `[ { rule1 }, { rule2 }, { rule3 } ]`. Each rule requires a `type` as described below in the examples.
 
@@ -30291,9 +30391,9 @@ URL: https://developers.fliplet.com/REST-API-Documentation.html
 
 # Fliplet REST API documentation
 
-<p class="warning"><strong>Note:</strong> Fliplet RESTful APIs are intended to be used by 3rd party software such as external integrations. <strong>If you want to interact with our APIs in a Fliplet App, please use the <a href="/API-Documentation.html">JS APIs</a> instead.</strong></p>
-
 Index of Fliplet REST endpoints for Data Sources, Media, Notifications, Apps, and more — intended for third-party integrations.
+
+<p class="warning"><strong>Note:</strong> Fliplet RESTful APIs are intended to be used by 3rd party software such as external integrations. <strong>If you want to interact with our APIs in a Fliplet App, please use the <a href="/API-Documentation.html">JS APIs</a> instead.</strong></p>
 
 ## Authentication
 
@@ -30359,7 +30459,7 @@ URL: https://developers.fliplet.com/REST-API/authenticate.html
 
 # Authenticating with the Fliplet REST APIs
 
-All Fliplet REST API requests are made over HTTPS to a regional endpoint (`api.fliplet.com`, `us.api.fliplet.com`, or `ca.api.fliplet.com`) and must include an auth token.
+Authenticate Fliplet REST API requests via the `Auth-token` header, an `Authorization: Bearer` header (base64), a `?auth_token=` query string, or a cookie, against the EU (`api.fliplet.com`), US (`us.api.fliplet.com`), or CA (`ca.api.fliplet.com`) endpoints over HTTPS.
 
 All requests must be made via ​**SSL​** to the above HTTPS-only endpoint.
 
@@ -32782,7 +32882,7 @@ URL: https://developers.fliplet.com/Theme-Settings-In-CSS.html
 
 # Use theme settings in your custom CSS
 
-Our theme is built with reusability in mind, therefore we used SCSS variables for all the settings so that you can use them in your custom CSS.
+Reference Fliplet theme SCSS variables (colors, typography, spacing) inside your custom CSS so your overrides inherit the theme's settings on a specific screen.
 
 Here is an example, let's say you want to override the background color of your `<body>` with the color of a button, on a specific screen:
 ```scss

--- a/docs/.well-known/llms.txt
+++ b/docs/.well-known/llms.txt
@@ -4,7 +4,7 @@
 
 ## Fliplet Core JavaScript APIs
 
-- [Fliplet.AI](https://developers.fliplet.com/API/core/ai.html): Build AI features in Fliplet apps with chat, completions, streaming, and task helpers — backed by OpenAI (GPT, o-series) or Google Gemini models via direct pro…
+- [Fliplet.AI](https://developers.fliplet.com/API/core/ai.html): Build AI features with `Fliplet.AI` — chat, completions, streaming, image generation, transcription, and embeddings via OpenAI or Google Gemini proxies.
 - [Fliplet.Analytics](https://developers.fliplet.com/API/core/analytics.html): Enable, disable, and check analytics tracking, and record custom app events and page views from JavaScript.
 - [Fliplet.API.request()](https://developers.fliplet.com/API/core/api.html): Make authenticated HTTP requests to Fliplet APIs with automatic URL construction, caching, offline queueing, and error handling.
 - [App Actions V2 (deprecated)](https://developers.fliplet.com/API/core/app-actions-v2.html): Deprecated App Actions V2 — configure a pipeline of functions that runs on-device or in the cloud, ad hoc or on a schedule. Migrate to V3.
@@ -18,10 +18,10 @@
 - [Fliplet.Env](https://developers.fliplet.com/API/core/environment.html): Read environment variables such as `appId`, `appName`, `mode`, and `apiUrl` from the current runtime.
 - [Fliplet.parseError()](https://developers.fliplet.com/API/core/error.html): Turn any error response or object into a human-readable message by scanning common error properties.
 - [Fliplet.Hooks](https://developers.fliplet.com/API/core/hooks.html): Register callbacks that run before or after key app events (e.g. form submit), with sync or async Promise handlers.
-- [Fliplet.Locale](https://developers.fliplet.com/API/core/localization.html): Customize your component to localize to different languages and regions.
+- [Fliplet.Locale](https://developers.fliplet.com/API/core/localization.html): Translate strings and format dates and numbers in Fliplet components via Fliplet.Locale, the T() shorthand, and translation.json files using i18next.
 - [Fliplet common functions](https://developers.fliplet.com/API/core/misc.html): Utility helpers on the global `Fliplet` object: `Fliplet.compile()` for templating and `Fliplet.guid()` for unique IDs.
-- [Fliplet.Modal](https://developers.fliplet.com/API/core/modal.html): Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio, powered by [Bootbox](http://bootboxjs.com/) — see its documentation for…
-- [Fliplet.Navigate](https://developers.fliplet.com/API/core/navigate.html): Navigate the app to a new page, screen, document or URL
+- [Fliplet.Modal](https://developers.fliplet.com/API/core/modal.html): Show confirmation, alert, and prompt dialogs from widget interfaces in Fliplet Studio via `Fliplet.Modal`, powered by Bootbox.
+- [Fliplet.Navigate](https://developers.fliplet.com/API/core/navigate.html): Navigate between app screens, open external URLs, pass query parameters, and handle back, home, and modal navigation via Fliplet.Navigate.
 - [Fliplet.Navigator](https://developers.fliplet.com/API/core/navigator.html): Detect online/offline state, listen for connectivity changes, and wait for the device to be ready.
 - [Fliplet.Navigator.Notifications](https://developers.fliplet.com/API/core/notifications.html): Check notification support, request permission, and send local device notifications from JavaScript.
 - [Fliplet.Organizations](https://developers.fliplet.com/API/core/organizations.html): List the current user's organizations and fetch audit logs with filters for type, date range, app, and session.
@@ -38,33 +38,33 @@
 
 - [Accordion component](https://developers.fliplet.com/API/components/accordions.html): The Accordion component supports query parameters to open specific accordions when linking to a screen.
 - [Charts component](https://developers.fliplet.com/API/components/charts.html): Use the Charts JS API to retrieve chart instances on a screen and update their data, labels, and series at runtime.
-- [Chat JS APIs](https://developers.fliplet.com/API/components/chat.html): These public JS APIs will be automatically available in your screens once a **Chat layout** component is used. You can also include these by manually adding th…
-- [Data Directory JS APIs](https://developers.fliplet.com/API/components/data-directory.html): These public JS APIs will be automatically available in your screens once a **Data Directory** component is dropped into such screens.
-- [Dynamic Container JS APIs](https://developers.fliplet.com/API/components/dynamic-container.html): The dynamic container allows you to dynamically load data from a data source in a screen. It is useful when you want to display a list of records in a screen u…
+- [Chat JS APIs](https://developers.fliplet.com/API/components/chat.html): Start conversations, list contacts, count unread messages, and modify chat rendering via Fliplet.Chat on screens that use the Chat layout component.
+- [Data Directory JS APIs](https://developers.fliplet.com/API/components/data-directory.html): Hook into the Data Directory component to override its data source, transform entries, and run code before render or initialization on directory screens.
+- [Dynamic Container JS APIs](https://developers.fliplet.com/API/components/dynamic-container.html): Bind a screen region to a data source query via Fliplet.DynamicContainer so the component renders a list of entries with bound expressions.
 - [Email Verification component](https://developers.fliplet.com/API/components/email-verification.html): Use the Email Verification JS API to retrieve the component instance on a screen and trigger verification flows for a given email address.
-- [Form JS APIs](https://developers.fliplet.com/API/components/form-builder.html): The following JS APIs are available in a screen once a **Form** component is dropped into the screen.
-- [Interactive Graphics JS APIs](https://developers.fliplet.com/API/components/interactive-graphics.html): These public JS APIs are available in screens where an **Interactive Graphics** component is present.
+- [Form JS APIs](https://developers.fliplet.com/API/components/form-builder.html): Populate fields, read values, react to validation, and submit programmatically via Fliplet.FormBuilder on screens that contain a Form component.
+- [Interactive Graphics JS APIs](https://developers.fliplet.com/API/components/interactive-graphics.html): Override marker data, preselect a marker or map, and respond to label clicks via Interactive Graphics component hooks on screens that use it.
 - [List (from Data Source) component](https://developers.fliplet.com/API/components/list-from-data-source.html): Configure templates, hooks, and query parameters for the List (from Data Source) component, which renders summary and detail views backed by a data source.
-- [List Repeater JS APIs](https://developers.fliplet.com/API/components/list-repeater.html): The list repeater component is a container for a list of records. It is used to display a list of records from a data source.
-- [Login](https://developers.fliplet.com/API/components/login.html): The login component fires hooks at key points in the authentication lifecycle. These allow you to run custom code after a user successfully logs in or when a r…
+- [List Repeater JS APIs](https://developers.fliplet.com/API/components/list-repeater.html): Render a list of data source entries inside a Dynamic Container via `Fliplet.ListRepeater`, with hooks to modify rows before and after render.
+- [Login](https://developers.fliplet.com/API/components/login.html): Run custom code after a user authenticates or when a returning user's session is re-validated via the Login component's `login` and `sessionValidate` hooks.
 - [Bottom Icon Bar menu component](https://developers.fliplet.com/API/components/menu-bottom-icon-bar.html): Use a query parameter to highlight the active item when linking into a screen that uses the Bottom Icon Bar menu component.
-- [Push Notifications JS APIs](https://developers.fliplet.com/API/components/push-notifications.html): These public JS APIs will be automatically available in your screens once **Push Notifications** have been enabled for your app.
-- [Record container JS APIs](https://developers.fliplet.com/API/components/record-container.html): The record container allows you to display one record from a data source in a screen. It is useful when you want to display a single record in a screen, for ex…
+- [Push Notifications JS APIs](https://developers.fliplet.com/API/components/push-notifications.html): Prompt users to subscribe, read device push settings, fetch the subscription ID and token, and unsubscribe via Fliplet's push notifications JS API.
+- [Record container JS APIs](https://developers.fliplet.com/API/components/record-container.html): Render a single data source entry in a screen via Fliplet.RecordContainer, with hooks to modify the query and react when data is retrieved.
 
 ## Helpers framework
 
 - [Distributing Helpers as components](https://developers.fliplet.com/API/helpers/components.html): Package a Fliplet Helper as a reusable widget-framework component so it can be installed and dropped into apps like any first-party component.
-- [Dynamic components](https://developers.fliplet.com/API/helpers/dynamic-components.html): Helpers can be dropped into what we refer as \"dynamic components\". These include the **Dynamic container** and **List Repeater** components. Such components su…
-- [Helper example: decision tree](https://developers.fliplet.com/API/helpers/example-decision-tree.html): Build a decision tree using the Fliplet Helper library.
+- [Dynamic components](https://developers.fliplet.com/API/helpers/dynamic-components.html): Render Helper instances inside Dynamic Container and List Repeater components, with reactive per-record data binding via `supportsDynamicContext`.
+- [Helper example: decision tree](https://developers.fliplet.com/API/helpers/example-decision-tree.html): Worked example: build a decision-tree Helper that presents a question, waits for the user's answer, then advances to the next question.
 - [Helper example: question and answer](https://developers.fliplet.com/API/helpers/example-question.html): A worked example showing how to build a Helper that presents a multiple-choice question and reveals whether the selected answer is correct.
 - [Helper fields (attributes)](https://developers.fliplet.com/API/helpers/fields.html): Pass attributes to a Helper via the HTML `field` element and read them inside the Helper via `this.fields.<name>`.
 - [Helper lifecycle hooks and events](https://developers.fliplet.com/API/helpers/hooks.html): Run code at key points in a Helper's lifecycle using the `beforeReady` and `ready` render hooks.
 - [Helper configuration interface: fields](https://developers.fliplet.com/API/helpers/interface-fields.html): Define the fields shown in a Helper's Fliplet Studio configuration interface, including their type, label, validation, and default value.
 - [Helper configuration interface: hooks and events](https://developers.fliplet.com/API/helpers/interface-hooks.html): Run code when a Helper's configuration interface initializes, becomes ready, or is about to save.
-- [Helper configuration interface: external libraries](https://developers.fliplet.com/API/helpers/interface-libraries.html): Include [Fliplet-approved](/Fliplet-approved-libraries.html) or third-party JavaScript and CSS libraries in a Helper's configuration interface via the `depende…
+- [Helper configuration interface: external libraries](https://developers.fliplet.com/API/helpers/interface-libraries.html): Include Fliplet-approved or third-party JavaScript and CSS libraries in a Helper's configuration interface via the `dependencies` array.
 - [Helper configuration interface: methods](https://developers.fliplet.com/API/helpers/interface-methods.html): Use `find`, `findOne`, and `children` inside a Helper's configuration interface to access nested child Helper instances.
 - [Helper configuration interface](https://developers.fliplet.com/API/helpers/interface.html): Define a configuration UI for your Helper so users can set field values for each instance from within Fliplet Studio.
-- [Helper external libraries](https://developers.fliplet.com/API/helpers/libraries.html): Declare a Helper's runtime dependencies by listing [Fliplet-approved](/Fliplet-approved-libraries.html) or third-party JS/CSS libraries in its `render.dependen…
+- [Helper external libraries](https://developers.fliplet.com/API/helpers/libraries.html): Declare a Helper's runtime dependencies by listing Fliplet-approved or third-party JS/CSS libraries in its `render.dependencies` array.
 - [Helper instance and class methods](https://developers.fliplet.com/API/helpers/methods.html): Define instance methods on a Helper and call Helper class methods such as `find` and `findOne` anywhere in the app lifecycle.
 - [Fliplet Helpers overview](https://developers.fliplet.com/API/helpers/overview.html): Helpers are a UI framework for building custom components in Fliplet apps using JavaScript, with a configuration interface in Fliplet Studio.
 - [Fliplet Helpers quickstart](https://developers.fliplet.com/API/helpers/quickstart.html): Create your first Fliplet Helper by defining its name, template, and configuration object in screen or global JavaScript.
@@ -78,7 +78,7 @@
 ## Data Sources
 
 - [Data Source joins](https://developers.fliplet.com/API/datasources/joins.html): Fetch related rows from multiple data sources in a single query using named joins, like SQL joins.
-- [Data Sources query operators](https://developers.fliplet.com/API/datasources/query-operators.html): Reference for MongoDB/Sift-style operators (`$eq`, `$gt`, `$in`, `$regex`, …) usable in `connection.find()` `where` clauses.
+- [Data Sources query operators](https://developers.fliplet.com/API/datasources/query-operators.html): Filter Data Source queries with MongoDB/Sift operators ($eq, $gt, $in, $regex, $and, $or) inside connection.find() where clauses.
 - [Data Source views](https://developers.fliplet.com/API/datasources/views.html): Define named, session-aware filters on a data source so each user or group sees only the rows that apply to them.
 
 ## Integrations
@@ -87,14 +87,14 @@
 
 ## Libraries
 
-- [Using Handlebars in your apps](https://developers.fliplet.com/API/libraries/handlebars.html): All screens of your Fliplet app already include [Handlebars `2.15.2`](https://handlebarsjs.com/) hence you can start using it straight away. Here's a quick exa…
+- [Using Handlebars in your apps](https://developers.fliplet.com/API/libraries/handlebars.html): Use Handlebars 2.15.2 in Fliplet app screens for templating, with built-in helpers for images, dates, auth URLs, JSON, and conditional comparisons.
 
 ## Providers
 
 - [Data Source provider](https://developers.fliplet.com/API/providers/data-source.html): The Data Source provider lets users pick or create a data source for a component, including default columns, entries, and access rules.
-- [Email provider](https://developers.fliplet.com/API/providers/email.html): The Email provider lets users compose and configure an email template (subject, body, recipients, headers) that can then be sent via `Fliplet.Communicate.sendE…
+- [Email provider](https://developers.fliplet.com/API/providers/email.html): Compose email templates (subject, body, recipients, headers) in a reusable provider UI for sending via `Fliplet.Communicate.sendEmail()`.
 - [File Picker provider](https://developers.fliplet.com/API/providers/file-picker.html): The File Picker provider lets users select one or more files from Fliplet's File Manager, optionally scoped by file type or restricted to single-select.
-- [Link Action provider](https://developers.fliplet.com/API/providers/link-action.html): The Link Action provider offers a reusable UI for configuring an action (e.g. navigate to screen, open URL, send email) that another feature will trigger on a…
+- [Link Action provider](https://developers.fliplet.com/API/providers/link-action.html): Configure link actions (navigate to screen, open URL, document, video, or run JS) in a reusable provider UI executable via `Fliplet.Navigate.to()`.
 
 ## Fliplet JavaScript APIs
 
@@ -102,39 +102,39 @@
 - [Fliplet.Media.Audio](https://developers.fliplet.com/API/fliplet-audio.html): Play, pause, stop, and seek audio files on device or from a URL in Fliplet apps via the Audio namespace.
 - [Fliplet.Barcode](https://developers.fliplet.com/API/fliplet-barcode.html): Scan QR codes and other 1D/2D barcodes from the device camera via the fliplet-barcode package.
 - [Fliplet.Communicate](https://developers.fliplet.com/API/fliplet-communicate.html): Send email, SMS, push notifications, and share URLs from a Fliplet app using a single Communicate namespace.
-- [Fliplet.Content()](https://developers.fliplet.com/API/fliplet-content.html): (Returns **`Promise`**)
+- [Fliplet.Content()](https://developers.fliplet.com/API/fliplet-content.html): Create, query, update, and delete shared content records (bookmarks, likes, saved searches) backed by a data source via Fliplet.Content.
 - [Fliplet.CSV](https://developers.fliplet.com/API/fliplet-csv.html): Encode and decode CSV in Fliplet apps via the fliplet-csv package.
 - [Fliplet.Database](https://developers.fliplet.com/API/fliplet-database.html): Low-level helper for reading and querying JSON data from a local file as a database; used internally by Fliplet.DataSources.
 - [Fliplet.DataSources](https://developers.fliplet.com/API/fliplet-datasources.html): Connect to, query, insert, update, and delete records in Fliplet Data Sources from inside an app. All methods are promise-based.
 - [Fliplet.DataSources.Encryption](https://developers.fliplet.com/API/fliplet-encryption.html): Automatically encrypt and decrypt selected Data Source columns on-device by registering a private key and column list.
-- [Fliplet.Gamify](https://developers.fliplet.com/API/fliplet-gamify.html): Configure gamification logic for your apps.
+- [Fliplet.Gamify](https://developers.fliplet.com/API/fliplet-gamify.html): Configure gamification with logs, variables, and achievements via Fliplet.Gamify; track points, milestones, and badges backed by a data source per user.
 - [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.
 - [Fliplet.Notifications](https://developers.fliplet.com/API/fliplet-notifications.html): Read, send, and schedule in-app and push notifications in Fliplet apps, with support for scopes, read receipts, and badge counts.
 - [Fliplet.OAuth2 (Beta)](https://developers.fliplet.com/API/fliplet-oauth2.html): The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
 - [Fliplet.Page](https://developers.fliplet.com/API/fliplet-page.html): Utilities for interacting with the current Fliplet screen — including smooth-scrolling to an element with configurable duration and offsets.
-- [Fliplet.Payments](https://developers.fliplet.com/API/fliplet-payments.html): Adds payments functionality in your Fliplet apps using Stripe and our easy-to-use JS API.
-- [Fliplet.Profile.Content()](https://developers.fliplet.com/API/fliplet-profile-content.html): (Returns **`Promise`**)
+- [Fliplet.Payments](https://developers.fliplet.com/API/fliplet-payments.html): Accept Stripe payments and checkout in Fliplet apps via Fliplet.Payments, with a products data source and webhook-driven order tracking.
+- [Fliplet.Profile.Content()](https://developers.fliplet.com/API/fliplet-profile-content.html): Create, query, update, and delete user-attributed content records in a data source so each user only sees their own entries via Fliplet.Profile.Content.
 - [Fliplet.Session](https://developers.fliplet.com/API/fliplet-session.html): Read, write, and clear the current user session — including cached offline sessions — for authentication state in Fliplet apps.
-- [Fliplet.UI.Table](https://developers.fliplet.com/API/fliplet-table.html): Fliplet.UI.Table is a powerful and flexible table component that provides features like sorting, searching, pagination, row selection, expandable rows, and cus…
+- [Fliplet.UI.Table](https://developers.fliplet.com/API/fliplet-table.html): Render searchable, sortable tables with pagination, row selection, expandable rows, and custom cell rendering via `Fliplet.UI.Table`.
 - [Fliplet.Themes](https://developers.fliplet.com/API/fliplet-themes.html): Read the list of available app themes and access the current theme's settings and widget-instance values at runtime.
-- [Fliplet.UI.Actions()](https://developers.fliplet.com/API/fliplet-ui-actions.html): (Returns **`Promise`**)
-- [Fliplet.UI.AddressField()](https://developers.fliplet.com/API/fliplet-ui-address.html): The Address field is a customizable component that integrates with Google Maps to enable address lookup. It allows users to search and select addresses using G…
-- [Fliplet.UI.DatePicker()](https://developers.fliplet.com/API/fliplet-ui-datepicker.html): (Returns `Object`)
-- [Fliplet.UI.DateRange()](https://developers.fliplet.com/API/fliplet-ui-daterange.html): (Returns `Object`)
-- [Fliplet.UI.NumberInput()](https://developers.fliplet.com/API/fliplet-ui-number.html): (Returns `Object`)
-- [Fliplet.UI.PanZoom](https://developers.fliplet.com/API/fliplet-ui-panzoom.html): These public JS APIs will be automatically available in your screen once an Interactive graphics component is dropped into a screen. You can also add the depen…
-- [Fliplet.UI.RangeSlider()](https://developers.fliplet.com/API/fliplet-ui-rangeslider.html): (Returns `Object`)
-- [Fliplet.UI.TimePicker()](https://developers.fliplet.com/API/fliplet-ui-timepicker.html): (Returns `Object`)
-- [Fliplet.UI.TimeRange()](https://developers.fliplet.com/API/fliplet-ui-timerange.html): (Returns `Object`)
-- [Fliplet.UI.Toast.error()](https://developers.fliplet.com/API/fliplet-ui-toast-error.html): (Returns **`undefined`**)
-- [Fliplet.UI.Toast()](https://developers.fliplet.com/API/fliplet-ui-toast.html): (Returns **`Promise`**)
-- [Fliplet.UI.Typeahead()](https://developers.fliplet.com/API/fliplet-ui-typeahead.html): (Returns `Object`)
-- [Fliplet.UI](https://developers.fliplet.com/API/fliplet-ui.html): The `Fliplet.UI` namespace contains several classes for creating UI managed by Fliplet. Where appropriate, the UI would come with the following benefits:
+- [Fliplet.UI.Actions()](https://developers.fliplet.com/API/fliplet-ui-actions.html): Show a native-style action sheet with a title, labeled options, and a cancel button, resolving with the chosen index via Fliplet.UI.Actions.
+- [Fliplet.UI.AddressField()](https://developers.fliplet.com/API/fliplet-ui-address.html): Add a Google Maps autocomplete address field to a screen via `Fliplet.UI.AddressField()` to search, select, and retrieve location details.
+- [Fliplet.UI.DatePicker()](https://developers.fliplet.com/API/fliplet-ui-datepicker.html): Render a date picker input with optional preset value, required flag, and get/set/change methods via Fliplet.UI.DatePicker.
+- [Fliplet.UI.DateRange()](https://developers.fliplet.com/API/fliplet-ui-daterange.html): Render a paired start/end date range input with required flag, default value, and get/set/change methods via Fliplet.UI.DateRange.
+- [Fliplet.UI.NumberInput()](https://developers.fliplet.com/API/fliplet-ui-number.html): Render a numeric input with required flag, preset value, and get/set/change methods for reading user-entered numbers via Fliplet.UI.NumberInput.
+- [Fliplet.UI.PanZoom](https://developers.fliplet.com/API/fliplet-ui-panzoom.html): Pan, zoom, and place markers on images or interactive graphics via `Fliplet.UI.PanZoom`, with pinch, mouse wheel, and double-tap support.
+- [Fliplet.UI.RangeSlider()](https://developers.fliplet.com/API/fliplet-ui-rangeslider.html): Render a range slider input with min, max, step, and default value, plus get/set/change methods via Fliplet.UI.RangeSlider.
+- [Fliplet.UI.TimePicker()](https://developers.fliplet.com/API/fliplet-ui-timepicker.html): Render a time picker input in 24-hour HH:mm format with required flag and get/set/change methods via Fliplet.UI.TimePicker.
+- [Fliplet.UI.TimeRange()](https://developers.fliplet.com/API/fliplet-ui-timerange.html): Render a paired start/end time range input in HH:mm format with required flag, default value, and get/set/change methods via Fliplet.UI.TimeRange.
+- [Fliplet.UI.Toast.error()](https://developers.fliplet.com/API/fliplet-ui-toast-error.html): Parse an error object and show a toast with a friendly initial message plus a button to reveal the detailed technical error via Fliplet.UI.Toast.error.
+- [Fliplet.UI.Toast()](https://developers.fliplet.com/API/fliplet-ui-toast.html): Show minimal or regular auto-dismissing toast notifications with title, message, position, duration, progress bar, and action buttons via Fliplet.UI.Toast.
+- [Fliplet.UI.Typeahead()](https://developers.fliplet.com/API/fliplet-ui-typeahead.html): Render a typeahead input with real-time suggestions, free-input toggle, max items, and get/set/change methods via Fliplet.UI.Typeahead.
+- [Fliplet.UI](https://developers.fliplet.com/API/fliplet-ui.html): Fliplet-managed UI primitives — toasts, action sheets, modals, date/time pickers, typeahead, tables, panzoom — under the Fliplet.UI namespace.
 - [Fliplet.LikeButton](https://developers.fliplet.com/API/like-buttons.html): Embed a one-tap like button on any screen element, backed by a Data Source that records likes per content ID.
 
 ## REST APIs
 
-- [Authenticating with the Fliplet REST APIs](https://developers.fliplet.com/REST-API/authenticate.html): All Fliplet REST API requests are made over HTTPS to a regional endpoint (`api.fliplet.com`, `us.api.fliplet.com`, or `ca.api.fliplet.com`) and must include an…
+- [Authenticating with the Fliplet REST APIs](https://developers.fliplet.com/REST-API/authenticate.html): Authenticate Fliplet REST API requests via Auth-token header, Authorization Bearer (base64), query string, or cookie against EU, US, or CA endpoints.
 - [App Analytics REST API](https://developers.fliplet.com/REST-API/fliplet-app-analytics.html): The App Analytics REST API lets you read your app's analytics data.
 - [App Subscriptions REST API](https://developers.fliplet.com/REST-API/fliplet-app-subscriptions.html): The App Subscriptions REST API lets you read and manage your app's users subscribed via push notifications.
 - [Apps REST API](https://developers.fliplet.com/REST-API/fliplet-apps.html): The Apps REST API lets external integrations list, read, create, update, and delete Fliplet apps that the auth token has access to.
@@ -146,9 +146,9 @@
 
 ## Component framework
 
-- [Output of components](https://developers.fliplet.com/components/Build-output.html): Components generally output HTML code when dropped into the page. Their output is compiled with [Handlebars](http://handlebarsjs.com/) using the `build.html` f…
-- [The component definition file](https://developers.fliplet.com/components/Definition.html): The `widget.json` file defines your component as well as the **dependencies** and **assets** it needs in order to run.
-- [Components interfaces](https://developers.fliplet.com/components/Interface.html): Components usually define interfaces to let their instances **save settings**.
+- [Output of components](https://developers.fliplet.com/components/Build-output.html): Render Fliplet component output from build.html via Handlebars; read per-instance settings with Fliplet.Widget.instance and support dynamic-container context.
+- [The component definition file](https://developers.fliplet.com/components/Definition.html): Define a Fliplet component in widget.json: name, package, version, icon, tags, html_tag, plus interface and build entries for dependencies and assets.
+- [Components interfaces](https://developers.fliplet.com/components/Interface.html): Build a Fliplet component's settings UI in interface.html with Handlebars; persist values via Fliplet.Widget.save and rehydrate with Fliplet.Widget.getData.
 - [Using providers](https://developers.fliplet.com/components/Using-Providers.html): Components can display providers to get specific data from the system or need a particular piece of functionality to be added.
 
 ## Automated App Builds
@@ -160,12 +160,12 @@
 - [Fliplet Developers documentation](https://developers.fliplet.com/): Reference and guides for extending Fliplet apps with the JS API, REST API, and custom components, themes, and menus.
 - [AI-powered Fliplet development with Cursor](https://developers.fliplet.com/AI-powered-development-with-Cursor.html): How to install and use the Fliplet VS Code extension inside Cursor to generate, refactor, and debug Fliplet app code with AI assistance.
 - [AJAX cross-domain and cross-origin requests](https://developers.fliplet.com/AJAX-cross-domain.html): How Fliplet apps handle AJAX cross-domain requests, common CORS errors, and the studio and app domains allowed by default.
-- [Fliplet analytics event reference](https://developers.fliplet.com/Analytics-documentation.html): Reference list of analytics event types Fliplet emits for page views, navigation, app management, sharing, and component interactions.
-- [JS API Documentation](https://developers.fliplet.com/API-Documentation.html): Javascript-based SDK to interact with core functions and components in your Fliplet Apps.
-- [Securing your apps](https://developers.fliplet.com/App-security.html): Fliplet apps can have each of their screens and data sources secured so that they can only be accessed when certain conditions are met. Take the following exam…
+- [Fliplet analytics event reference](https://developers.fliplet.com/Analytics-documentation.html): List the analytics event types Fliplet emits for page views, navigation, app management, sharing, and component interactions.
+- [JS API Documentation](https://developers.fliplet.com/API-Documentation.html): Index of Fliplet's JavaScript APIs (Core, Data Sources, Media, UI, Communicate) for working with apps, screens, users, and components from custom code.
+- [Securing your apps](https://developers.fliplet.com/App-security.html): Restrict screen and data-source access in Fliplet apps via login conditions, IP allow/deny lists, and custom JS rules using session and page context.
 - [Fliplet-approved JavaScript libraries (coding-standards edition)](https://developers.fliplet.com/approved-libraries.html): The JavaScript libraries Fliplet pre-approves for app development, why you should prefer them over custom ones, and when to reach for each.
-- [Writing more readable code when using the JS APIs](https://developers.fliplet.com/Async-await.html): As you might know most of Fliplet JS APIs use **Promises** when the result of such operation cannot be read synchronously. For example when reading data from t…
-- [Best practice and advices when building components](https://developers.fliplet.com/Best-practises.html): Got stuck building components or found some nasty bugs? Here's a few tips that might help you dealing with basic issues during the development of components on…
+- [Writing more readable code when using the JS APIs](https://developers.fliplet.com/Async-await.html): Use async/await with Fliplet's Promise-based JS APIs for cleaner data-source reads, navigation, hooks, and user-session code, with try/catch error handling.
+- [Best practice and advices when building components](https://developers.fliplet.com/Best-practises.html): Gotchas for Fliplet components: instance data, multi-drop handling, Handlebars escaping for Vue/Angular curly braces, and required dependencies.
 - [Building Fliplet components](https://developers.fliplet.com/Building-components.html): How to scaffold, run, and develop a Fliplet component locally using the CLI, including the generated file layout and the local dev server.
 - [Building Fliplet app action functions](https://developers.fliplet.com/Building-functions.html): How to scaffold and develop an app action function with the CLI, declare its dependencies, and configure it via widget.json.
 - [Building Fliplet menus](https://developers.fliplet.com/Building-menus.html): How to scaffold a Fliplet menu widget, configure its position and settings via menu.json, and develop its template and assets.
@@ -174,24 +174,25 @@
 - [Cloning widgets, components, and themes from the CLI](https://developers.fliplet.com/Cloning-widgets.html): How to use the fliplet clone and fliplet list CLI commands to download the source of a published component, menu, or theme to your machine.
 - [Fliplet API patterns and categories](https://developers.fliplet.com/code-api-patterns.html): Overview of the main Fliplet JS API categories (Data Sources, Users, Media, Navigation) and when to pick each one.
 - [Fliplet coding and documentation standards](https://developers.fliplet.com/coding-standards.html): Coding and documentation standards used across Fliplet APIs, components, and examples, so both humans and AI tools produce consistent Fliplet code.
-- [Component events](https://developers.fliplet.com/Component-events.html): When components are moved around the page in *Edit* mode, Fliplet provides a set of events to manage the user interaction.
-- [Context targeting](https://developers.fliplet.com/Context-targeting.html): Fliplet uses [Modernizr](https://modernizr.com/) (`v3.5.0`) to help developers target users with specific device capabilities and contexts. This lets you targe…
-- [Custom Headers](https://developers.fliplet.com/Custom-Headers.html): Fliplet allows you to set custom headers for your apps. This feature is useful for enhancing security, controlling resource loading, and adding custom HTTP hea…
+- [Component events](https://developers.fliplet.com/Component-events.html): Listen for component lifecycle events (adding, added, removed, moved, render) emitted while users edit a Fliplet screen, via Fliplet.Hooks.on('componentEvent').
+- [Context targeting](https://developers.fliplet.com/Context-targeting.html): Target devices in Fliplet apps via Modernizr classes and JS flags for iOS, Android, Windows, web, native, mobile/tablet/desktop, notch, and Studio edit mode.
+- [Custom Headers](https://developers.fliplet.com/Custom-Headers.html): Configure custom HTTP response headers (CSP, HSTS, CORS, custom security headers) for a Fliplet app via Fliplet.App.Settings and the Developer Options panel.
 - [Custom HTML templates for Fliplet components](https://developers.fliplet.com/Custom-template-for-components.html): How to override a component's default template with custom HTML and Handlebars in the new container-based drag-and-drop system.
 - [Fliplet infrastructure data flow](https://developers.fliplet.com/Data-flow.html): Architecture diagram showing how data flows between Fliplet Studio, Fliplet servers, app clients, and connected data sources.
 - [Data integration service](https://developers.fliplet.com/Data-integration-service.html): Fliplet Agent (Data integration service) is a command line utility to synchronize data to and from Fliplet Servers.
-- [Data Source Hooks](https://developers.fliplet.com/Data-Source-Hooks.html): Data Source hooks allow your app's backend to perform certain operations such as **sending emails** or **push notifications** when certain conditions occur, e.…
+- [Data Source Hooks](https://developers.fliplet.com/Data-Source-Hooks.html): Trigger emails, SMS, push notifications, web requests, or column operations on Data Source insert/update/beforeSave/beforeQuery using Sift.js match conditions.
 - [Securing Fliplet data sources](https://developers.fliplet.com/Data-source-security.html): Secure your Data Sources with access rules, data requirements, and custom JavaScript security rules.
-- [Dependencies and assets](https://developers.fliplet.com/Dependencies-and-assets.html): Both **components** and **themes** can specify a list of dependencies and local assets which should be used when rendering it.
+- [Dependencies and assets](https://developers.fliplet.com/Dependencies-and-assets.html): Declare package dependencies and bundled JS/CSS/font assets for Fliplet components and themes, with separate interface and build entries plus appAssets.
 - [Sending events between components](https://developers.fliplet.com/Event-emitter.html): Components interfaces can send events to Fliplet Studio using a event emitter bus provided with the `fliplet-core` dependency.
 - [Fliplet app execution flow](https://developers.fliplet.com/Execution-flow.html): The rendering and hook lifecycle Fliplet apps go through before a screen is shown to the user, and where to safely run custom code within it.
 - [Securing Fliplet files and folders](https://developers.fliplet.com/File-security.html): Secure files and folders in your Fliplet apps with access rules and custom JavaScript security rules.
 - [Fliplet-approved JavaScript libraries (reference list)](https://developers.fliplet.com/Fliplet-approved-libraries.html): Reference list of every JavaScript library Fliplet pre-approves in apps, including versions and optional add-on libraries.
-- [Fliplet SDK](https://developers.fliplet.com/Fliplet-SDK.html): The Fliplet SDK enables you to use all the JS APIs outside of our environment. This means you can use them on any client-side code which is not sitting on Flip…
+- [Fliplet SDK](https://developers.fliplet.com/Fliplet-SDK.html): Load Fliplet JS APIs on any external website via sdk.js with an auth token and optional comma-separated package list (e.g. fliplet-media, fliplet-datasources).
 - [Integrating Fliplet apps with external APIs](https://developers.fliplet.com/Integrate-with-external-API.html): Call third-party REST APIs from a Fliplet app using jQuery AJAX helpers, including CORS considerations.
 - [Introduction to the Fliplet developer platform](https://developers.fliplet.com/Introduction.html): Overview of the Fliplet developer stack (JavaScript, SASS, Handlebars) and the kinds of apps, components, themes, and menus you can build on it.
 - [JavaScript coding standards for Fliplet apps](https://developers.fliplet.com/javascript-coding-standards.html): Recommended ES6+ patterns for new Fliplet code and ES5 patterns for legacy apps, covering promises, async/await, and API integration.
 - [The Fliplet JavaScript APIs](https://developers.fliplet.com/JS-APIs.html): How the Fliplet JS APIs (SDK, not a framework) let you interact with data, screens, users, and components from Studio custom code, themes, and widgets.
+- [fliplet-docs-mcp](https://developers.fliplet.com/mcp-worker/README.html): Cloudflare Worker exposing an MCP server at developers.fliplet.com/mcp with search_fliplet_docs and fetch_fliplet_doc tools backed by llms.txt.
 - [Native framework changelog](https://developers.fliplet.com/Native-framework-changelog.html): Release notes for the Fliplet iOS and Android native frameworks — rebuild your app against a newer version to unlock new features.
 - [Fliplet open source resources](https://developers.fliplet.com/open-source.html): Where to find Fliplet's open-source code, pre-built app solutions, screen templates, community code examples, and developer documentation.
 - [Organization audit log types](https://developers.fliplet.com/Organization-audit-log-types.html): Reference table of every audit log type emitted for Fliplet organizations, queryable via the JS or REST API.
@@ -199,11 +200,11 @@
 - [Advanced features for the iOS platform](https://developers.fliplet.com/Platform-iOS.html): How to detect iOS at runtime and supply a manual P12 certificate when using Fliplet's Automated App Build with an Apple Enterprise account.
 - [Publishing components, themes and menus](https://developers.fliplet.com/Publishing.html): How to publish Fliplet components, themes, and menus to the Fliplet platform using the CLI's publish command.
 - [Fliplet CLI quickstart](https://developers.fliplet.com/Quickstart.html): Install Node.js and the Fliplet CLI so you can develop and test components, themes, and menus on your machine.
-- [Rate limiting for APIs](https://developers.fliplet.com/Rate-limiting-for-API.html): If you’re integrating your app or service with Fliplet APIs, you should be mindful in relation to how frequent your requests are hitting our APIs. Our infrastructure is set up to automatically thrott…
-- [Reduce your app bundle size](https://developers.fliplet.com/Reduce-app-bundle-size.html): Blacklist assets from your Fliplet app bundle to shrink it for App Store and Google Play submission.
+- [Rate limiting for APIs](https://developers.fliplet.com/Rate-limiting-for-API.html): Fliplet rate-limits Data Source, Communicate, audit-log, AI, and App Action APIs per user; back off on 429 responses and batch writes via the commit endpoint.
+- [Reduce your app bundle size](https://developers.fliplet.com/Reduce-app-bundle-size.html): Exclude assets from your Fliplet app bundle by content type, file extension, or media file ID to shrink it for App Store and Google Play submission.
 - [Fliplet REST API documentation](https://developers.fliplet.com/REST-API-Documentation.html): Index of Fliplet REST endpoints for Data Sources, Media, Notifications, Apps, and more — intended for third-party integrations.
 - [Testing Fliplet components](https://developers.fliplet.com/Testing-components.html): Run and write tests for a Fliplet component using the CLI's test command, backed by Mocha, Chai, and Puppeteer.
-- [Use theme settings in your custom CSS](https://developers.fliplet.com/Theme-Settings-In-CSS.html): Our theme is built with reusability in mind, therefore we used SCSS variables for all the settings so that you can use them in your custom CSS.
+- [Use theme settings in your custom CSS](https://developers.fliplet.com/Theme-Settings-In-CSS.html): Reference Fliplet theme SCSS variables (colors, typography, spacing) inside your custom CSS to inherit the theme's settings on a specific screen.
 - [Theme and appearance settings for components](https://developers.fliplet.com/Theming-appearance.html): Expose configurable colors, fonts, and other CSS properties in Fliplet Studio's theme settings UI via your component's widget.json.
 - [UI guidelines for component output (build)](https://developers.fliplet.com/UI-guidelines-build.html): Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's user-facing output.
 - [UI guidelines for component settings (interface)](https://developers.fliplet.com/UI-guidelines-interface.html): Recommended Bootstrap-based styles for buttons, forms, and typography in a Fliplet component's Studio settings interface.

--- a/docs/.well-known/mcp/server-card.json
+++ b/docs/.well-known/mcp/server-card.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "2025-06-18",
+  "serverInfo": {
+    "name": "fliplet-docs-mcp",
+    "title": "Fliplet developer docs MCP server",
+    "version": "0.1.0"
+  },
+  "transport": {
+    "type": "streamable_http",
+    "url": "https://developers.fliplet.com/mcp"
+  },
+  "capabilities": {
+    "tools": [
+      {
+        "name": "search_fliplet_docs",
+        "description": "Fuzzy-search the Fliplet developer documentation index (llms.txt). Returns ranked matches with title, URL, description, group, and relevance score."
+      },
+      {
+        "name": "fetch_fliplet_doc",
+        "description": "Fetch the raw Markdown source of a single Fliplet developer documentation page. URL must be under developers.fliplet.com and end in .md."
+      }
+    ]
+  },
+  "documentation": "https://developers.fliplet.com/"
+}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -75,15 +75,25 @@ docs/**/*.md
    │
    ├── node bin/build-agent-indexes.mjs
    │     ↓
-   │     docs/.well-known/{llms.txt, llms-full.txt, agent-skills/index.json, api-catalog}
+   │     docs/.well-known/{
+   │       llms.txt, llms-full.txt,
+   │       agent-skills/index.json,
+   │       agent-skills/<cluster>/SKILL.md   (12 capability clusters),
+   │       mcp/server-card.json,
+   │       api-catalog
+   │     }
    │
    ├── bundle exec jekyll build
    │     ↓
-   │     docs/_site/**/*.html  (plus any files under docs/.well-known/ get copied in)
+   │     docs/_site/**/*.html
+   │     (Jekyll is configured to SKIP .well-known/ — see _config.yml.
+   │      Its SKILL.md frontmatter would otherwise trigger Jekyll's
+   │      Markdown→HTML conversion and break the URLs we publish.)
    │
    └── node bin/copy-md-siblings.mjs
          ↓
-         docs/_site/<path>.md   (source markdown, sibling of each HTML)
+         docs/_site/<path>.md       (source .md sibling of each .html)
+         docs/_site/.well-known/**  (verbatim copy, post-Jekyll)
 ```
 
 Run locally:
@@ -108,9 +118,11 @@ These are the AI-consumption surfaces. Publish URLs on `developers.fliplet.com`:
 
 | Path | Format | Purpose |
 |---|---|---|
-| `/.well-known/llms.txt` | llmstxt.org text | Grouped one-line index of all docs |
+| `/.well-known/llms.txt` | llmstxt.org text | Grouped one-line index of all docs (per-page) |
 | `/.well-known/llms-full.txt` | Concatenated markdown | Full content of all docs for clients that want to ingest in bulk |
-| `/.well-known/agent-skills/index.json` | Agent Skills v0.2.0 | Schema-compliant skill registry with SHA256 per doc |
+| `/.well-known/agent-skills/index.json` | Agent Skills v0.2.0 | Capability-clustered skill registry (12 entries, SHA256 per cluster's SKILL.md) |
+| `/.well-known/agent-skills/<cluster>/SKILL.md` | Markdown w/ frontmatter | Per-cluster entry point listing the cluster's docs |
+| `/.well-known/mcp/server-card.json` | SEP-1649 server card | Discovery for the MCP Worker at `/mcp` |
 | `/.well-known/api-catalog` | RFC 9727 linkset+json | Linkset discovery |
 
 `_headers` sets CORS (`Access-Control-Allow-Origin: *`) and `Cache-Control:
@@ -128,18 +140,24 @@ homepage HTML) and `/index.md` (the raw markdown).
 This is a stopgap for Cloudflare Pages' future native Markdown-for-Agents
 feature; when that ships we can drop the copy step.
 
-## MCP server (Phase 3, not yet deployed)
+## MCP server
 
-The repo plans a Cloudflare Worker at `developers.fliplet.com/mcp` exposing
-an MCP server over Streamable HTTP with `search_fliplet_docs` and
-`fetch_fliplet_doc` tools. Until that ships, AI clients should:
+A Cloudflare Worker at `developers.fliplet.com/mcp` exposes an MCP server
+over Streamable HTTP with two tools:
 
-- Fetch `/.well-known/llms.txt` for discovery
-- Fetch `<path>.md` for full content
-- Use `fliplet-kb` (the Fliplet-internal MCP server) for broader search
-  across code + internal docs; it will expose its dev-docs tool as
-  `search_fliplet_dev_docs` to avoid collision with the new MCP server
-  when both are configured.
+- `search_fliplet_docs({ query, limit?, tags?, type? })` — fuzzy-search
+  the index built from `.well-known/llms.txt`.
+- `fetch_fliplet_doc({ url })` — fetch the raw Markdown of a single doc
+  page; SSRF-safe (URL must be under `developers.fliplet.com` and end in
+  `.md`).
+
+Source lives at `mcp-worker/`. Deploy with `cd mcp-worker && npx wrangler
+deploy` from a machine with Cloudflare credentials. Discovery is published
+at `/.well-known/mcp/server-card.json` per SEP-1649.
+
+`fliplet-kb` (the Fliplet-internal code-and-docs MCP server) renames its
+dev-docs-scoped tool to `search_fliplet_dev_docs` to avoid collision with
+this server when an AI client is configured with both.
 
 ## Skill routing
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,8 +5,12 @@ plugins:
 
 include:
   - _headers
-  - .well-known
 
+# .well-known is intentionally NOT in `include:` — its contents are copied
+# verbatim by bin/copy-md-siblings.mjs after Jekyll runs. Letting Jekyll
+# touch it converts SKILL.md → SKILL.html (because they carry YAML
+# frontmatter), which would break the URLs we publish in agent-skills
+# index.json.
 exclude:
   - docsearch
   - bin
@@ -16,3 +20,4 @@ exclude:
   - package.json
   - node_modules
   - CLAUDE.md
+  - .well-known

--- a/docs/bin/__tests__/build-agent-indexes.test.mjs
+++ b/docs/bin/__tests__/build-agent-indexes.test.mjs
@@ -13,6 +13,10 @@ import {
   truncate,
   emitLlmsTxt,
   emitAgentSkills,
+  emitSkillMd,
+  emitMcpServerCard,
+  assignToCluster,
+  CLUSTERS,
   collectDocs,
 } from '../build-agent-indexes.mjs';
 
@@ -182,23 +186,112 @@ describe('emitLlmsTxt', () => {
   });
 });
 
+describe('assignToCluster', () => {
+  it('routes data-source docs to fliplet-data-sources', () => {
+    assert.equal(assignToCluster('API/fliplet-datasources.md').name, 'fliplet-data-sources');
+    assert.equal(assignToCluster('API/datasources/joins.md').name, 'fliplet-data-sources');
+    assert.equal(assignToCluster('Data-source-security.md').name, 'fliplet-data-sources');
+    assert.equal(assignToCluster('File-security.md').name, 'fliplet-data-sources');
+  });
+
+  it('routes app-actions docs (all versions) to fliplet-app-actions', () => {
+    assert.equal(assignToCluster('API/core/app-actions.md').name, 'fliplet-app-actions');
+    assert.equal(assignToCluster('API/core/app-actions-v2.md').name, 'fliplet-app-actions');
+    assert.equal(assignToCluster('API/core/app-actions-v3.md').name, 'fliplet-app-actions');
+  });
+
+  it('routes REST API docs to fliplet-rest-api', () => {
+    assert.equal(assignToCluster('REST-API/Apps.md').name, 'fliplet-rest-api');
+    assert.equal(assignToCluster('REST-API-Documentation.md').name, 'fliplet-rest-api');
+  });
+
+  it('routes themes docs (incl. API/fliplet-themes.md) to fliplet-themes-framework', () => {
+    assert.equal(assignToCluster('Building-themes.md').name, 'fliplet-themes-framework');
+    assert.equal(assignToCluster('API/fliplet-themes.md').name, 'fliplet-themes-framework');
+  });
+
+  it('routes oauth2 to fliplet-integrations (specific match wins over API/ catch-all)', () => {
+    assert.equal(assignToCluster('API/fliplet-oauth2.md').name, 'fliplet-integrations');
+  });
+
+  it('routes generic API/* docs to fliplet-js-api', () => {
+    assert.equal(assignToCluster('API/fliplet-storage.md').name, 'fliplet-js-api');
+    assert.equal(assignToCluster('API/core/storage.md').name, 'fliplet-js-api');
+    assert.equal(assignToCluster('API/components/charts.md').name, 'fliplet-js-api');
+  });
+
+  it('routes unmatched general/onboarding docs to the fallback', () => {
+    assert.equal(assignToCluster('Introduction.md').name, 'fliplet-docs-index');
+    assert.equal(assignToCluster('Quickstart.md').name, 'fliplet-docs-index');
+    assert.equal(assignToCluster('README.md').name, 'fliplet-docs-index');
+    assert.equal(assignToCluster('Async-await.md').name, 'fliplet-docs-index');
+  });
+
+  it('lists the fallback cluster last so it is least preferred by ordering-aware rankers', () => {
+    assert.equal(CLUSTERS[CLUSTERS.length - 1].name, 'fliplet-docs-index');
+  });
+});
+
 describe('emitAgentSkills', () => {
-  it('produces v0.2.0 schema with one skill per doc', () => {
+  it('produces a cluster-shaped index (one entry per cluster, no $schema, no per-doc type)', () => {
+    const summaries = new Map();
+    for (const c of CLUSTERS) summaries.set(c.name, { skillMdSha256: 'a'.repeat(64), count: 0 });
+    const out = emitAgentSkills(summaries);
+    assert.equal(out.$schema, undefined, 'no broken $schema URL');
+    assert.equal(out.skills.length, CLUSTERS.length);
+    for (const skill of out.skills) {
+      assert.ok(skill.name.startsWith('fliplet-'), 'every cluster name uses fliplet- prefix');
+      assert.ok(skill.url.endsWith('/SKILL.md'), 'url points at SKILL.md, not landing page');
+      assert.equal(skill.type, undefined, 'no spec-foreign type field');
+      assert.match(skill.sha256, /^[a-f0-9]{64}$/);
+      assert.ok(Array.isArray(skill.tags));
+    }
+  });
+
+  it('places fliplet-docs-index last in the index', () => {
+    const summaries = new Map();
+    for (const c of CLUSTERS) summaries.set(c.name, { skillMdSha256: '0'.repeat(64), count: 0 });
+    const out = emitAgentSkills(summaries);
+    assert.equal(out.skills[out.skills.length - 1].name, 'fliplet-docs-index');
+  });
+});
+
+describe('emitSkillMd', () => {
+  it('renders frontmatter + doc list for a capability cluster', () => {
+    const cluster = CLUSTERS.find((c) => c.name === 'fliplet-data-sources');
     const docs = [
-      {
-        title: 'Doc One',
-        url: 'https://ex.com/a',
-        description: 'Summary one',
-        skillName: 'doc-one',
-        sha256: 'abc123',
-      },
+      { title: 'Fliplet.DataSources', url: 'https://x/a.html', description: 'JS API.' },
+      { title: 'Joins', url: 'https://x/b.html', description: 'Joins.' },
     ];
-    const out = emitAgentSkills(docs);
-    assert.equal(out.$schema, 'https://agentskills.io/schema/v0.2.0/index.json');
-    assert.equal(out.skills.length, 1);
-    assert.equal(out.skills[0].name, 'doc-one');
-    assert.equal(out.skills[0].type, 'documentation');
-    assert.equal(out.skills[0].sha256, 'abc123');
+    const md = emitSkillMd(cluster, docs);
+    assert.ok(md.startsWith('---\nname: fliplet-data-sources\n'));
+    assert.ok(md.includes('# Fliplet data sources'));
+    assert.ok(md.includes('- [Fliplet.DataSources](https://x/a.html): JS API.'));
+    assert.ok(md.includes('- [Joins](https://x/b.html): Joins.'));
+    assert.ok(md.includes('## How to load full content'));
+    assert.ok(md.includes('https://developers.fliplet.com/mcp'));
+  });
+
+  it('renders fallback body that names every other cluster', () => {
+    const cluster = CLUSTERS.find((c) => c.name === 'fliplet-docs-index');
+    const md = emitSkillMd(cluster, []);
+    assert.ok(md.includes('Prefer a specific Fliplet skill'));
+    for (const c of CLUSTERS) {
+      if (c.name === 'fliplet-docs-index') continue;
+      assert.ok(md.includes('`' + c.name + '`'), `fallback names ${c.name}`);
+    }
+    assert.ok(md.includes('/.well-known/llms.txt'));
+  });
+});
+
+describe('emitMcpServerCard', () => {
+  it('emits a SEP-1649-shaped card for the streamable-HTTP MCP endpoint', () => {
+    const card = emitMcpServerCard();
+    assert.equal(card.serverInfo.name, 'fliplet-docs-mcp');
+    assert.equal(card.transport.type, 'streamable_http');
+    assert.equal(card.transport.url, 'https://developers.fliplet.com/mcp');
+    const toolNames = card.capabilities.tools.map((t) => t.name);
+    assert.deepEqual(toolNames.sort(), ['fetch_fliplet_doc', 'search_fliplet_docs']);
   });
 });
 

--- a/docs/bin/__tests__/copy-md-siblings.test.mjs
+++ b/docs/bin/__tests__/copy-md-siblings.test.mjs
@@ -6,7 +6,7 @@ import { strict as assert } from 'node:assert';
 import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { siblingTargetForRelPath, copySiblings } from '../copy-md-siblings.mjs';
+import { siblingTargetForRelPath, copySiblings, copyWellKnown } from '../copy-md-siblings.mjs';
 
 describe('siblingTargetForRelPath', () => {
   it('maps README.md to index.md for homepage serving', () => {
@@ -74,6 +74,65 @@ describe('copySiblings', () => {
       /_site directory not found/,
     );
     rmSync(missingRoot, { recursive: true, force: true });
+  });
+
+  // Cleanup
+  it('(teardown)', () => {
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('copyWellKnown', () => {
+  const root = join(tmpdir(), `copy-well-known-test-${Date.now()}`);
+  const site = join(root, '_site');
+  const wk = join(root, '.well-known');
+
+  mkdirSync(wk, { recursive: true });
+  mkdirSync(join(wk, 'agent-skills', 'fliplet-data-sources'), { recursive: true });
+  mkdirSync(join(wk, 'mcp'), { recursive: true });
+  mkdirSync(site, { recursive: true });
+
+  writeFileSync(join(wk, 'llms.txt'), 'index\n');
+  writeFileSync(join(wk, 'api-catalog'), '{}\n');
+  writeFileSync(join(wk, 'agent-skills', 'index.json'), '{"skills":[]}\n');
+  writeFileSync(
+    join(wk, 'agent-skills', 'fliplet-data-sources', 'SKILL.md'),
+    '---\nname: fliplet-data-sources\n---\n# DS\n',
+  );
+  writeFileSync(join(wk, 'mcp', 'server-card.json'), '{"x":1}\n');
+
+  it('copies every file under .well-known/ verbatim', () => {
+    const count = copyWellKnown(root, site);
+    assert.equal(count, 5);
+    assert.ok(existsSync(join(site, '.well-known', 'llms.txt')));
+    assert.ok(existsSync(join(site, '.well-known', 'api-catalog')));
+    assert.ok(existsSync(join(site, '.well-known', 'agent-skills', 'index.json')));
+    assert.ok(
+      existsSync(join(site, '.well-known', 'agent-skills', 'fliplet-data-sources', 'SKILL.md')),
+    );
+    assert.ok(existsSync(join(site, '.well-known', 'mcp', 'server-card.json')));
+  });
+
+  it('preserves SKILL.md byte-for-byte (no Jekyll conversion)', () => {
+    const original = readFileSync(
+      join(wk, 'agent-skills', 'fliplet-data-sources', 'SKILL.md'),
+      'utf8',
+    );
+    const copied = readFileSync(
+      join(site, '.well-known', 'agent-skills', 'fliplet-data-sources', 'SKILL.md'),
+      'utf8',
+    );
+    assert.equal(copied, original);
+  });
+
+  it('throws a clear error when .well-known/ does not exist', () => {
+    const empty = join(tmpdir(), `copy-wk-missing-${Date.now()}`);
+    mkdirSync(join(empty, '_site'), { recursive: true });
+    assert.throws(
+      () => copyWellKnown(empty, join(empty, '_site')),
+      /\.well-known directory not found/,
+    );
+    rmSync(empty, { recursive: true, force: true });
   });
 
   // Cleanup

--- a/docs/bin/build-agent-indexes.mjs
+++ b/docs/bin/build-agent-indexes.mjs
@@ -5,10 +5,18 @@
 //
 // Inputs:  docs/**/*.md (walks filesystem directly)
 // Outputs: docs/.well-known/
-//   llms.txt                  — llmstxt.org format, grouped by area
-//   llms-full.txt             — concatenated markdown of all docs
-//   agent-skills/index.json   — Agent Skills Discovery v0.2.0
-//   api-catalog               — RFC 9727 linkset+json
+//   llms.txt                              — llmstxt.org format, grouped by area
+//   llms-full.txt                         — concatenated markdown of all docs
+//   agent-skills/index.json               — Agent Skills Discovery v0.2.0,
+//                                           cluster-shaped (one skill per
+//                                           Fliplet capability area, not per
+//                                           doc page)
+//   agent-skills/<cluster>/SKILL.md       — auto-generated entry point for
+//                                           each cluster, listing its docs
+//   mcp/server-card.json                  — MCP Server Card (SEP-1649) for
+//                                           the Worker at developers.fliplet
+//                                           .com/mcp
+//   api-catalog                           — RFC 9727 linkset+json
 //
 // Title comes from frontmatter `title:` if present, else the H1 (stripped of
 // enclosing backticks). Description comes from frontmatter `description:` if
@@ -24,8 +32,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const docsRoot = resolve(here, '..');
 const wellKnownDir = join(docsRoot, '.well-known');
 const agentSkillsDir = join(wellKnownDir, 'agent-skills');
+const mcpDir = join(wellKnownDir, 'mcp');
 
 const BASE_URL = 'https://developers.fliplet.com';
+const MCP_ENDPOINT = `${BASE_URL}/mcp`;
 const SITE_TITLE = 'Fliplet Developers';
 const SITE_DESCRIPTION =
   'Developer documentation for the Fliplet platform — JavaScript APIs, REST APIs, component and helper frameworks, and developer guides for building apps, components, themes, and integrations on Fliplet.';
@@ -80,6 +90,181 @@ function pickGroup(relPath) {
     if (relPath.startsWith(g.prefix)) return g.label;
   }
   return 'Guides';
+}
+
+// Cluster definitions for agent-skills/index.json. Each cluster represents a
+// Fliplet capability area (the right shape for Agent Skills v0.2.0, which is
+// designed for capability-level discovery — not per-doc indexing; that's what
+// llms.txt is for).
+//
+// Order matters: assignToCluster() returns the FIRST matching cluster, so
+// narrower predicates must come before broader ones. The catch-all fallback
+// (`fliplet-docs-index`) lives last and intentionally describes itself as a
+// fallback so embedding rankers score it low on capability queries.
+export const CLUSTERS = [
+  {
+    name: 'fliplet-data-sources',
+    title: 'Fliplet data sources',
+    description:
+      'Data sources JavaScript API and security model: query, insert, update, delete records; row-level security; file storage; data-source hooks.',
+    landingUrl: `${BASE_URL}/API/fliplet-datasources.html`,
+    tags: ['data-sources', 'js-api', 'security'],
+    match: (p) =>
+      p.startsWith('API/datasources/') ||
+      p === 'API/fliplet-datasources.md' ||
+      p === 'Data-source-security.md' ||
+      p === 'Data-Source-Hooks.md' ||
+      p === 'Data-flow.md' ||
+      p === 'File-security.md',
+  },
+  {
+    name: 'fliplet-app-actions',
+    title: 'Fliplet App Actions (server-side automations)',
+    description:
+      'Build server-side automations that run on a schedule or in response to events. Covers App Actions v1, v2, and v3 APIs.',
+    landingUrl: `${BASE_URL}/API/core/app-actions.html`,
+    tags: ['app-actions', 'js-api', 'server-side'],
+    match: (p) => /^API\/core\/app-actions(-v[23])?\.md$/.test(p),
+  },
+  {
+    name: 'fliplet-helpers-framework',
+    title: 'Fliplet helpers framework',
+    description:
+      'Build helpers — reusable Vue-based interface components with editable interface fields, hooks, methods, libraries, and templates.',
+    landingUrl: `${BASE_URL}/API/helpers/overview.html`,
+    tags: ['helpers-framework', 'components-framework'],
+    match: (p) => p.startsWith('API/helpers/'),
+  },
+  {
+    name: 'fliplet-rest-api',
+    title: 'Fliplet REST API',
+    description:
+      'Server-side REST API for managing organizations, apps, users, data sources, files, and screens from your own backend.',
+    landingUrl: `${BASE_URL}/REST-API-Documentation.html`,
+    tags: ['rest-api', 'server-side'],
+    match: (p) =>
+      p.startsWith('REST-API/') ||
+      p === 'REST-API-Documentation.md' ||
+      p === 'Rate-limiting-for-API.md',
+  },
+  {
+    name: 'fliplet-components-framework',
+    title: 'Fliplet components framework',
+    description:
+      'Build custom components (widgets) that ship inside Fliplet apps: component definitions, lifecycle, events, dependencies, providers, custom templates, testing.',
+    landingUrl: `${BASE_URL}/Building-components.html`,
+    tags: ['components-framework', 'widgets'],
+    match: (p) =>
+      p.startsWith('components/') ||
+      p === 'Building-components.md' ||
+      p === 'Building-functions.md' ||
+      p === 'Component-events.md' ||
+      p === 'Cloning-widgets.md' ||
+      p === 'Context-targeting.md' ||
+      p === 'Custom-Headers.md' ||
+      p === 'Custom-template-for-components.md' ||
+      p === 'Dependencies-and-assets.md' ||
+      p === 'Testing-components.md' ||
+      p === 'UI-guidelines-build.md' ||
+      p === 'UI-guidelines-interface.md',
+  },
+  {
+    name: 'fliplet-themes-framework',
+    title: 'Fliplet themes framework',
+    description:
+      'Build custom themes that control app appearance: color palettes, typography, theme settings exposed in the editor, CSS overrides.',
+    landingUrl: `${BASE_URL}/Building-themes.html`,
+    tags: ['themes-framework'],
+    match: (p) =>
+      p === 'Building-themes.md' ||
+      p === 'Theme-Settings-In-CSS.md' ||
+      p === 'Theming-appearance.md' ||
+      p === 'API/fliplet-themes.md',
+  },
+  {
+    name: 'fliplet-menus-framework',
+    title: 'Fliplet menus framework',
+    description:
+      'Build custom menus that ship inside Fliplet apps to navigate between screens.',
+    landingUrl: `${BASE_URL}/Building-menus.html`,
+    tags: ['menus-framework'],
+    match: (p) => p === 'Building-menus.md',
+  },
+  {
+    name: 'fliplet-app-build-and-publish',
+    title: 'Fliplet app build and publish',
+    description:
+      'Publish Fliplet apps to iOS, Android, and the web: bundle size, certificates, automated app builds, platform-specific gotchas.',
+    landingUrl: `${BASE_URL}/Publishing.html`,
+    tags: ['publish', 'platform'],
+    match: (p) =>
+      p === 'Publishing.md' ||
+      p === 'Platform-iOS.md' ||
+      p === 'Platform-Android.md' ||
+      p.startsWith('aab/') ||
+      p === 'Reduce-app-bundle-size.md',
+  },
+  {
+    name: 'fliplet-security-and-compliance',
+    title: 'Fliplet security and compliance',
+    description:
+      'App-level security, IP allowlisting, organization audit logs, privacy controls. (Data-source-level security lives in fliplet-data-sources.)',
+    landingUrl: `${BASE_URL}/App-security.html`,
+    tags: ['security', 'compliance'],
+    match: (p) =>
+      p === 'App-security.md' ||
+      p === 'URLs-and-IP-Addresses.md' ||
+      p === 'Organization-audit-log-types.md',
+  },
+  {
+    name: 'fliplet-integrations',
+    title: 'Fliplet integrations',
+    description:
+      'Integrate with external systems: SSO/SAML2, the Data Integration Service, external REST APIs, OAuth2, AJAX cross-domain.',
+    landingUrl: `${BASE_URL}/Data-integration-service.html`,
+    tags: ['integrations', 'sso', 'oauth'],
+    match: (p) =>
+      p.startsWith('API/integrations/') ||
+      p === 'Data-integration-service.md' ||
+      p === 'Integrate-with-external-API.md' ||
+      p === 'AJAX-cross-domain.md' ||
+      p === 'API/fliplet-oauth2.md',
+  },
+  {
+    name: 'fliplet-js-api',
+    title: 'Fliplet JavaScript API (Fliplet.*)',
+    description:
+      'The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User, Navigate, Profile, Communicate, Media, Notifications, UI, ...).',
+    landingUrl: `${BASE_URL}/API-Documentation.html`,
+    tags: ['js-api'],
+    match: (p) =>
+      p.startsWith('API/') ||
+      p === 'API-Documentation.md' ||
+      p === 'JS-APIs.md' ||
+      p === 'Fliplet-SDK.md' ||
+      p === 'Fliplet-approved-libraries.md' ||
+      p === 'approved-libraries.md' ||
+      p === 'code-api-patterns.md',
+  },
+  // Fallback last. Description is intentionally meta-heavy and capability-
+  // light so embedding rankers score it low on domain queries. Tagged
+  // `fallback` so tag filters can deprioritize.
+  {
+    name: 'fliplet-docs-index',
+    title: 'Fliplet developer documentation (fallback index)',
+    description:
+      'Site-wide index of the Fliplet developer documentation. Use only as a fallback when no other Fliplet skill (js-api, rest-api, data-sources, app-actions, components-framework, helpers-framework, themes-framework, menus-framework, app-build-and-publish, security-and-compliance, integrations) matches your query. Points at /.well-known/llms.txt for full-site discovery.',
+    landingUrl: `${BASE_URL}/`,
+    tags: ['meta', 'index', 'fallback'],
+    match: () => true,
+  },
+];
+
+export function assignToCluster(relPath) {
+  for (const c of CLUSTERS) {
+    if (c.match(relPath)) return c;
+  }
+  return CLUSTERS[CLUSTERS.length - 1]; // unreachable; fallback always matches
 }
 
 function shouldExclude(relPath) {
@@ -250,16 +435,98 @@ export function emitLlmsFullTxt(docs) {
     .join('\n---\n\n');
 }
 
-export function emitAgentSkills(docs) {
+// Build the cluster-shaped agent-skills index. Each entry points at a
+// SKILL.md emitted under .well-known/agent-skills/<cluster>/SKILL.md.
+// `sha256` is the digest of the rendered SKILL.md so consumers can detect
+// drift the same way they could with per-doc entries.
+export function emitAgentSkills(docsByCluster) {
   return {
-    $schema: 'https://agentskills.io/schema/v0.2.0/index.json',
-    skills: docs.map((doc) => ({
-      name: doc.skillName,
-      type: 'documentation',
-      description: doc.description,
-      url: doc.url,
-      sha256: doc.sha256,
-    })),
+    skills: CLUSTERS.map((c) => {
+      const entry = docsByCluster.get(c.name) || { skillMdSha256: '', count: 0 };
+      return {
+        name: c.name,
+        title: c.title,
+        description: c.description,
+        url: `${BASE_URL}/.well-known/agent-skills/${c.name}/SKILL.md`,
+        landingUrl: c.landingUrl,
+        tags: c.tags,
+        sha256: entry.skillMdSha256,
+      };
+    }),
+  };
+}
+
+// Render the SKILL.md body for a cluster. Body lists every doc the cluster
+// owns (auto-generated; new docs added under a matching path appear without
+// edits). The fallback cluster gets a different body that explicitly tells
+// the agent to prefer specific clusters first.
+export function emitSkillMd(cluster, docsInCluster) {
+  const fm = `---\nname: ${cluster.name}\ndescription: ${cluster.description}\n---\n`;
+
+  if (cluster.name === 'fliplet-docs-index') {
+    return (
+      fm +
+      `\n# Fliplet developer documentation index\n\n` +
+      `${cluster.description}\n\n` +
+      `## Prefer a specific Fliplet skill\n\n` +
+      `Before loading this fallback skill, check whether one of the following matches your query:\n\n` +
+      CLUSTERS.filter((c) => c.name !== 'fliplet-docs-index')
+        .map((c) => `- \`${c.name}\` — ${c.description}`)
+        .join('\n') +
+      `\n\n## Full site index\n\n` +
+      `If no specific skill matches, fetch [${BASE_URL}/.well-known/llms.txt](${BASE_URL}/.well-known/llms.txt) for the complete list of every Fliplet developer doc, grouped by area. Each entry is a one-line summary; replace \`.html\` with \`.md\` on any doc URL to fetch the raw Markdown.\n\n` +
+      `## MCP server\n\n` +
+      `For tool-driven discovery, point an MCP-aware client at [${MCP_ENDPOINT}](${MCP_ENDPOINT}). The server exposes \`search_fliplet_docs\` and \`fetch_fliplet_doc\`.\n`
+    );
+  }
+
+  const docList = docsInCluster
+    .map((d) => `- [${d.title}](${d.url})${d.description ? `: ${d.description}` : ''}`)
+    .join('\n');
+
+  return (
+    fm +
+    `\n# ${cluster.title}\n\n` +
+    `${cluster.description}\n\n` +
+    `## Documentation\n\n` +
+    docList +
+    `\n\n## How to load full content\n\n` +
+    `Replace \`.html\` with \`.md\` on any URL above to fetch the raw Markdown source. To search across all Fliplet developer docs, use the MCP server at [${MCP_ENDPOINT}](${MCP_ENDPOINT}) (tools: \`search_fliplet_docs\`, \`fetch_fliplet_doc\`), or fetch [${BASE_URL}/.well-known/llms-full.txt](${BASE_URL}/.well-known/llms-full.txt) for the entire site as a single stream.\n`
+  );
+}
+
+// MCP Server Card per SEP-1649
+// (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127).
+// The schema is still being standardized; consumers that pre-date the SEP
+// can still consume `serverInfo`, `transport`, and `capabilities.tools` —
+// those are the load-bearing fields validators check today.
+export function emitMcpServerCard() {
+  return {
+    schemaVersion: '2025-06-18',
+    serverInfo: {
+      name: 'fliplet-docs-mcp',
+      title: 'Fliplet developer docs MCP server',
+      version: '0.1.0',
+    },
+    transport: {
+      type: 'streamable_http',
+      url: MCP_ENDPOINT,
+    },
+    capabilities: {
+      tools: [
+        {
+          name: 'search_fliplet_docs',
+          description:
+            'Fuzzy-search the Fliplet developer documentation index (llms.txt). Returns ranked matches with title, URL, description, group, and relevance score.',
+        },
+        {
+          name: 'fetch_fliplet_doc',
+          description:
+            'Fetch the raw Markdown source of a single Fliplet developer documentation page. URL must be under developers.fliplet.com and end in .md.',
+        },
+      ],
+    },
+    documentation: `${BASE_URL}/`,
   };
 }
 
@@ -285,12 +552,14 @@ export function collectDocs(rootDir) {
     const title = fm.title || h1;
     const description = fm.description || intro || '';
     const sha256 = createHash('sha256').update(raw).digest('hex');
+    const cluster = assignToCluster(relPath);
     docs.push({
       relPath,
       url: urlForPath(relPath),
       title,
       description: truncate(description, 200),
       group: pickGroup(relPath),
+      cluster: cluster.name,
       sha256,
       skillName: skillNameForPath(relPath),
       body,
@@ -305,6 +574,7 @@ function main() {
   console.log(`Discovered ${docs.length} docs for indexing`);
 
   mkdirSync(agentSkillsDir, { recursive: true });
+  mkdirSync(mcpDir, { recursive: true });
 
   const llmsTxt = emitLlmsTxt(docs);
   writeFileSync(join(wellKnownDir, 'llms.txt'), llmsTxt);
@@ -312,10 +582,34 @@ function main() {
   const llmsFull = emitLlmsFullTxt(docs);
   writeFileSync(join(wellKnownDir, 'llms-full.txt'), llmsFull);
 
-  const agentSkills = emitAgentSkills(docs);
+  // Group docs by cluster, render SKILL.md per cluster, hash each rendered
+  // SKILL.md for the index entry's sha256, then emit the cluster-shaped
+  // index.json.
+  const docsByClusterName = new Map();
+  for (const c of CLUSTERS) docsByClusterName.set(c.name, []);
+  for (const d of docs) docsByClusterName.get(d.cluster).push(d);
+
+  const skillSummaries = new Map();
+  for (const c of CLUSTERS) {
+    const clusterDocs = docsByClusterName.get(c.name);
+    const skillMd = emitSkillMd(c, clusterDocs);
+    const skillMdSha256 = createHash('sha256').update(skillMd).digest('hex');
+    const clusterDir = join(agentSkillsDir, c.name);
+    mkdirSync(clusterDir, { recursive: true });
+    writeFileSync(join(clusterDir, 'SKILL.md'), skillMd);
+    skillSummaries.set(c.name, { skillMdSha256, count: clusterDocs.length });
+  }
+
+  const agentSkills = emitAgentSkills(skillSummaries);
   writeFileSync(
     join(agentSkillsDir, 'index.json'),
     JSON.stringify(agentSkills, null, 2) + '\n',
+  );
+
+  const mcpCard = emitMcpServerCard();
+  writeFileSync(
+    join(mcpDir, 'server-card.json'),
+    JSON.stringify(mcpCard, null, 2) + '\n',
   );
 
   const apiCatalog = emitApiCatalog(docs);
@@ -327,7 +621,12 @@ function main() {
   console.log('Generated:');
   console.log(`  .well-known/llms.txt                 (${llmsTxt.length} bytes, ${docs.length} entries)`);
   console.log(`  .well-known/llms-full.txt            (${llmsFull.length} bytes)`);
-  console.log(`  .well-known/agent-skills/index.json  (${docs.length} skills)`);
+  console.log(`  .well-known/agent-skills/index.json  (${CLUSTERS.length} clusters, ${docs.length} docs)`);
+  for (const c of CLUSTERS) {
+    const n = skillSummaries.get(c.name).count;
+    console.log(`    └─ ${c.name.padEnd(34)} (${n} doc${n === 1 ? '' : 's'})`);
+  }
+  console.log(`  .well-known/mcp/server-card.json     (${MCP_ENDPOINT})`);
   console.log(`  .well-known/api-catalog              (${docs.length} entries)`);
 }
 

--- a/docs/bin/copy-md-siblings.mjs
+++ b/docs/bin/copy-md-siblings.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Copy source .md files into _site/ as siblings of their generated .html.
+// Copy source .md files into _site/ as siblings of their generated .html,
+// AND copy docs/.well-known/ into _site/.well-known/ verbatim.
 // Run AFTER `bundle exec jekyll build`.
 //
 // Jekyll converts foo/bar.md → _site/foo/bar.html. This script additionally
@@ -7,6 +8,10 @@
 // Markdown at the same URL path with a .md suffix. Combined with _headers'
 // `Content-Type: text/markdown` rule, this is a stopgap until Cloudflare's
 // native Markdown-for-Agents feature ships.
+//
+// .well-known/ is excluded from Jekyll (see _config.yml) so its SKILL.md
+// frontmatter doesn't trigger Jekyll's Markdown converter. We copy the
+// directory verbatim here instead.
 //
 // Stdlib only.
 
@@ -103,9 +108,53 @@ export function copySiblings(rootDir, outDir) {
   return count;
 }
 
+// Walk every file under a directory, yielding { fullPath, relPath }.
+// Used for the .well-known/ copy (we don't filter by extension since
+// .well-known holds .json, .txt, extensionless files, and SKILL.md).
+function* walkAll(dir, rootDir = dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    const rel = relative(rootDir, full).split(sep).join('/');
+    if (entry.isDirectory()) {
+      yield* walkAll(full, rootDir);
+    } else if (entry.isFile()) {
+      yield { fullPath: full, relPath: rel };
+    }
+  }
+}
+
+// Copy docs/.well-known/ → _site/.well-known/ byte-for-byte. Jekyll is
+// configured to skip .well-known entirely (see _config.yml), so without
+// this step _site/.well-known/ would not exist.
+export function copyWellKnown(rootDir, outDir) {
+  const sourceDir = join(rootDir, '.well-known');
+  const targetDir = join(outDir, '.well-known');
+  if (!existsSync(sourceDir)) {
+    throw new Error(
+      `.well-known directory not found: ${sourceDir}. Run \`node bin/build-agent-indexes.mjs\` first.`,
+    );
+  }
+  let count = 0;
+  for (const { fullPath, relPath } of walkAll(sourceDir)) {
+    const target = join(targetDir, relPath);
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(fullPath, target);
+    count++;
+  }
+  return count;
+}
+
 function main() {
-  const count = copySiblings(docsRoot, siteDir);
-  console.log(`Copied ${count} .md siblings into _site/`);
+  const siblingCount = copySiblings(docsRoot, siteDir);
+  console.log(`Copied ${siblingCount} .md siblings into _site/`);
+  const wellKnownCount = copyWellKnown(docsRoot, siteDir);
+  console.log(`Copied ${wellKnownCount} files from .well-known/ into _site/.well-known/`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary

Two fixes in one PR, both improving how AI clients discover Fliplet docs:

**1. Reshape `agent-skills/index.json` from per-doc to per-cluster.**
The previous index listed every `.md` file as an individual "skill" (174 entries). That's the wrong layer — Agent Skills v0.2.0 is for capability-level discovery, while per-page indexing belongs in `llms.txt` (which we already publish). This PR collapses those 174 entries into 12 capability clusters:

| Cluster | Docs | Landing |
|---|---|---|
| fliplet-data-sources | 8 | `/API/fliplet-datasources.html` |
| fliplet-app-actions | 3 | `/API/core/app-actions.html` |
| fliplet-helpers-framework | 21 | `/API/helpers/overview.html` |
| fliplet-rest-api | 11 | `/REST-API-Documentation.html` |
| fliplet-components-framework | 15 | `/Building-components.html` |
| fliplet-themes-framework | 4 | `/Building-themes.html` |
| fliplet-menus-framework | 1 | `/Building-menus.html` |
| fliplet-app-build-and-publish | 5 | `/Publishing.html` |
| fliplet-security-and-compliance | 3 | `/App-security.html` |
| fliplet-integrations | 5 | `/Data-integration-service.html` |
| fliplet-js-api | 81 | `/API-Documentation.html` |
| fliplet-docs-index (fallback) | 17 | `/` |

Each cluster gets an auto-generated `.well-known/agent-skills/<name>/SKILL.md` listing its docs. The fallback cluster is listed last with `tags: ["meta", "index", "fallback"]` and capability-light description so any reasonable ranker scores it low for domain queries.

**2. Publish MCP Server Card (SEP-1649) at `/.well-known/mcp/server-card.json`.**
Resolves the validator gap (e.g. isitagentready.com) flagging "MCP Server Card not found." The card declares `serverInfo`, the streamable-HTTP `transport.url`, and the two `capabilities.tools` exposed by `mcp-worker/`. The Worker code already lives in this repo at `mcp-worker/`; deploying it is a separate `wrangler deploy` step. This PR ships the discovery file so once the Worker deploys, validators see it immediately.

**Cleanups:**
- Drop the unresolvable `$schema: https://agentskills.io/schema/v0.2.0/index.json` URL (404, never existed).
- Drop spec-foreign `type: "documentation"` per-entry field.

**Build pipeline change:**
Jekyll now skips `.well-known/` entirely (was previously in `include:`). `SKILL.md` carries YAML frontmatter, which Jekyll's Markdown converter interprets as a Jekyll page and converts to `.html`, breaking the URLs we publish in `index.json`. `bin/copy-md-siblings.mjs` now copies the directory verbatim post-Jekyll via `copyWellKnown()`.

## Test plan

- [x] `npm run test:unit` — 54/54 pass (added: `assignToCluster`, cluster-shaped `emitAgentSkills`, `emitSkillMd` capability + fallback variants, `emitMcpServerCard`, `copyWellKnown`)
- [x] Local pipeline: `node bin/build-agent-indexes.mjs && bundle exec jekyll build && node bin/copy-md-siblings.mjs` — clean, 174 docs across 12 clusters, no `SKILL.html` artifacts
- [x] `_site/.well-known/agent-skills/fliplet-data-sources/SKILL.md` exists as raw markdown (Jekyll didn't touch it)
- [x] `_site/.well-known/mcp/server-card.json` exists with correct shape
- [x] CF Pages preview build serves `/.well-known/agent-skills/index.json` with 12 cluster entries
- [x] CF Pages preview serves `/.well-known/agent-skills/fliplet-data-sources/SKILL.md` with `Content-Type: text/markdown`
- [x] CF Pages preview serves `/.well-known/mcp/server-card.json` with `Content-Type: application/json`
- [ ] Post-merge: re-run validator at isitagentready.com — MCP Server Card should now be detected

## Follow-up (not in this PR)

The MCP Worker at `mcp-worker/` needs a one-time `wrangler deploy` from a machine with Cloudflare credentials. Until that runs, `developers.fliplet.com/mcp` returns the Pages catchall (HTML), and any client that loads the server card and tries to connect will fail. Card is correct; Worker just isn't bound yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)