### PR TITLE
fix(docs): no doubled CORS+Cache on .well-known/**/SKILL.md

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,9 +1,14 @@
 # CF Pages applies all matching rule blocks (specific path AND wildcard
-# combine). To avoid duplicating Access-Control-Allow-Origin and
-# Cache-Control on every response, common headers live in the wildcard
-# block; specific blocks below it carry only Content-Type overrides.
+# combine). When multiple matching blocks set the SAME header, CF Pages
+# concatenates the values — it does not deduplicate or override. So we
+# avoid having two blocks set the same header on the same path.
+#
+# In particular: SKILL.md files under .well-known/agent-skills/ are .md
+# files, so they would match both /*.md AND any /.well-known/* wildcard.
+# The wildcard for .well-known/ is therefore split by extension below so
+# .md paths only match /*.md (single CORS+Cache).
 
-# Content-Type overrides for specific paths
+# Content-Type overrides for paths CF Pages can't auto-detect:
 /.well-known/api-catalog
   Content-Type: application/linkset+json
 
@@ -13,13 +18,23 @@
 /.well-known/llms-full.txt
   Content-Type: text/plain; charset=utf-8
 
-# Common headers for everything under /.well-known/
-/.well-known/*
+# CORS + Cache for non-.md files under /.well-known/. Split by extension
+# so .md paths fall through to /*.md below and don't get doubled headers.
+/.well-known/*.txt
   Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=3600
 
-# Markdown sibling files served with text/markdown + CORS so AI clients
-# can fetch raw source from the same URL paths as the generated HTML.
+/.well-known/*.json
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+/.well-known/api-catalog
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+# Markdown sibling files (both /API/foo.md AND /.well-known/agent-skills/
+# <cluster>/SKILL.md) served with text/markdown + CORS so AI clients can
+# fetch raw source from the same URL paths as the generated HTML.
 /*.md
   Content-Type: text/markdown; charset=utf-8
   Access-Control-Allow-Origin: *


### PR DESCRIPTION
## Summary

`SKILL.md` files under `.well-known/agent-skills/<cluster>/` matched **both** `/*.md` and `/.well-known/*` wildcards in `_headers`. CF Pages concatenates same-name header values from multiple matching blocks, so the response carried doubled values:

```
$ curl -sI https://developers.fliplet.com/.well-known/agent-skills/fliplet-data-sources/SKILL.md
access-control-allow-origin: *, *
cache-control: public, max-age=3600, public, max-age=3600
```

`Access-Control-Allow-Origin: *, *` is **invalid per the CORS spec** — browsers reject the header, so cross-origin fetches of `SKILL.md` from any browser-based AI client fail. Server-side fetches (the MCP Worker, curl, server-rendered agents) were unaffected, since CORS is browser-only.

## Fix

Split `/.well-known/*` into extension-specific blocks (`*.txt`, `*.json`, plus the existing extensionless `api-catalog`). `.md` paths under `.well-known/` now fall through to `/*.md` only, getting single CORS+Cache values, the same as `/API/foo.md` and every other Markdown sibling.

## Test plan

- [ ] Post-merge, verify single values:
  - [ ] `curl -sI https://developers.fliplet.com/.well-known/agent-skills/fliplet-data-sources/SKILL.md` → single CORS, single Cache
  - [ ] `curl -sI https://developers.fliplet.com/.well-known/llms.txt` → CORS+Cache+text/plain
  - [ ] `curl -sI https://developers.fliplet.com/.well-known/api-catalog` → CORS+Cache+linkset+json
  - [ ] `curl -sI https://developers.fliplet.com/.well-known/agent-skills/index.json` → CORS+Cache+application/json
  - [ ] `curl -sI https://developers.fliplet.com/.well-known/mcp/server-card.json` → CORS+Cache+application/json
  - [ ] `curl -sI https://developers.fliplet.com/API/fliplet-datasources.md` (control) → unchanged, single values

🤖 Generated with [Claude Code](https://claude.com/claude-code)