### PR TITLE
fix(docs): restore Content-Type: application/linkset+json on api-catalog

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,40 +1,49 @@
-# CF Pages applies all matching rule blocks (specific path AND wildcard
-# combine). When multiple matching blocks set the SAME header, CF Pages
-# concatenates the values — it does not deduplicate or override. So we
-# avoid having two blocks set the same header on the same path.
+# CF Pages applies matching rule blocks together. Two empirically-verified
+# behaviors shape this file:
 #
-# In particular: SKILL.md files under .well-known/agent-skills/ are .md
-# files, so they would match both /*.md AND any /.well-known/* wildcard.
-# The wildcard for .well-known/ is therefore split by extension below so
-# .md paths only match /*.md (single CORS+Cache).
+# 1. When multiple matching blocks set the SAME header, CF Pages
+#    concatenates the values. We saw this with `Access-Control-Allow-
+#    Origin: *, *` on SKILL.md when /*.md and /.well-known/* both matched.
+#    Browsers reject `*, *` per the CORS spec, so we must not double up.
+#
+# 2. When TWO blocks share the SAME exact path, CF Pages keeps only the
+#    last block — earlier blocks for that path are discarded entirely.
+#    We saw this with /.well-known/api-catalog: a Content-Type-only block
+#    followed by a CORS+Cache block lost the Content-Type override and
+#    fell back to application/octet-stream.
+#
+# So: per-path blocks must be SINGLE and CARRY ALL HEADERS, and wildcard
+# overlap with /*.md must be avoided.
 
-# Content-Type overrides for paths CF Pages can't auto-detect:
+# Per-path blocks for paths where CF Pages can't auto-detect Content-Type
+# or where the file has no extension. Each block carries every header that
+# applies to that path, in one shot.
 /.well-known/api-catalog
   Content-Type: application/linkset+json
-
-/.well-known/llms.txt
-  Content-Type: text/plain; charset=utf-8
-
-/.well-known/llms-full.txt
-  Content-Type: text/plain; charset=utf-8
-
-# CORS + Cache for non-.md files under /.well-known/. Split by extension
-# so .md paths fall through to /*.md below and don't get doubled headers.
-/.well-known/*.txt
   Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=3600
 
+/.well-known/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+/.well-known/llms-full.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+# .json under /.well-known/ — CF Pages auto-detects Content-Type for the
+# .json extension; we just add CORS + Cache. Matches index.json (agent
+# skills) and mcp/server-card.json.
 /.well-known/*.json
   Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=3600
 
-/.well-known/api-catalog
-  Access-Control-Allow-Origin: *
-  Cache-Control: public, max-age=3600
-
-# Markdown sibling files (both /API/foo.md AND /.well-known/agent-skills/
-# <cluster>/SKILL.md) served with text/markdown + CORS so AI clients can
-# fetch raw source from the same URL paths as the generated HTML.
+# Markdown sibling files. Matches both /API/foo.md (Jekyll output sibling)
+# and /.well-known/agent-skills/<cluster>/SKILL.md. The .well-known
+# wildcards above are extension-scoped so they don't ALSO match here and
+# double the CORS+Cache values.
 /*.md
   Content-Type: text/markdown; charset=utf-8
   Access-Control-Allow-Origin: *


### PR DESCRIPTION
## Summary

Regression from #248. Splitting \`/.well-known/*\` into extension-scoped wildcards left two separate blocks for the extensionless \`/.well-known/api-catalog\` path: a Content-Type-only block and a CORS+Cache-only block. CF Pages keeps only the LAST block when two share the same exact path — the Content-Type override was discarded and api-catalog fell back to \`application/octet-stream\`:

\`\`\`
$ curl -sI https://developers.fliplet.com/.well-known/api-catalog
content-type: application/octet-stream      ← regression
access-control-allow-origin: *
cache-control: public, max-age=3600
\`\`\`

## Fix

Merge each per-path block in \`_headers\` into a single block carrying ALL the headers that apply (Content-Type + CORS + Cache). Drop the now-redundant \`/.well-known/*.txt\` wildcard since llms.txt and llms-full.txt are the only .txt files there and now carry their headers explicitly.

Document both CF Pages quirks (concatenation across blocks; last-wins on same-path duplicates) at the top of \`_headers\` so future edits don't re-introduce either failure mode.

## Test plan

Post-merge, every primitive should carry exactly one of each header:

- [ ] \`/.well-known/api-catalog\` → \`application/linkset+json\` + CORS + Cache
- [ ] \`/.well-known/llms.txt\` → \`text/plain; charset=utf-8\` + CORS + Cache
- [ ] \`/.well-known/llms-full.txt\` → \`text/plain; charset=utf-8\` + CORS + Cache
- [ ] \`/.well-known/agent-skills/index.json\` → \`application/json\` + CORS + Cache
- [ ] \`/.well-known/mcp/server-card.json\` → \`application/json\` + CORS + Cache
- [ ] \`/.well-known/agent-skills/fliplet-data-sources/SKILL.md\` → \`text/markdown\` + CORS + Cache (single)
- [ ] \`/API/fliplet-datasources.md\` (control) → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)