### PR TITLE
ci: auto-deploy mcp-worker on push to master

### DIFF
--- a/.github/workflows/deploy-mcp-worker.yml
+++ b/.github/workflows/deploy-mcp-worker.yml
@@ -1,0 +1,88 @@
+name: Deploy MCP Worker
+
+# Auto-deploys the Cloudflare Worker at developers.fliplet.com/mcp whenever
+# anything under docs/mcp-worker/ changes on the default branch. Cloudflare
+# Pages auto-deploys the docs site itself on every push, but Workers are a
+# separate deployment unit and require an explicit `wrangler deploy` — this
+# workflow makes that automatic so we never have to remember to run it.
+#
+# Required repo secrets (set under Settings → Secrets and variables → Actions):
+#   CLOUDFLARE_API_TOKEN   — token with permission "Account → Cloudflare
+#                            Workers Scripts:Edit" and zone access on
+#                            fliplet.com (because the Worker route is bound
+#                            to a developers.fliplet.com path).
+#   CLOUDFLARE_ACCOUNT_ID  — the Fliplet Cloudflare account ID (visible in
+#                            the dashboard sidebar on any account-scoped
+#                            page).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      # NOTE: deliberately not triggering on changes to this workflow file
+      # itself, so merging the PR that introduces or edits the workflow
+      # doesn't immediately attempt a deploy (which would fail before the
+      # required secrets are added the first time). Use workflow_dispatch
+      # below to verify a workflow edit on demand.
+      - 'docs/mcp-worker/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Test, typecheck, deploy
+    defaults:
+      run:
+        working-directory: docs/mcp-worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'docs/mcp-worker/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: docs/mcp-worker
+          command: deploy
+
+      - name: Smoke-test the live Worker
+        # Verify the deployed Worker actually responds with the expected
+        # tools list. CF Workers usually propagate within a few seconds, but
+        # we give it 15s of grace to avoid flaky failures right after deploy.
+        run: |
+          set -euo pipefail
+          sleep 15
+          RESP=$(curl -fsX POST https://developers.fliplet.com/mcp \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
+          echo "$RESP" | head -c 500
+          echo
+          if ! echo "$RESP" | grep -q 'search_fliplet_docs'; then
+            echo "::error::Smoke test failed — search_fliplet_docs tool not in response."
+            exit 1
+          fi
+          if ! echo "$RESP" | grep -q 'fetch_fliplet_doc'; then
+            echo "::error::Smoke test failed — fetch_fliplet_doc tool not in response."
+            exit 1
+          fi
+          echo "OK: deployed Worker advertises both expected tools."


### PR DESCRIPTION
## Summary

Cloudflare Pages auto-deploys the docs site on every push, but Workers are a separate deployment unit and require an explicit \`wrangler deploy\`. Until now that's been a manual step (lbroom@fliplet.com runs it when \`docs/mcp-worker/\` changes), which means the live Worker drifts from master between deploys.

This workflow makes Worker deploys automatic on any push to master that touches \`docs/mcp-worker/**\`. Steps:

1. Install deps (\`npm ci\` against the lockfile)
2. Run unit tests + typecheck (we don't deploy if either fails)
3. Deploy via \`cloudflare/wrangler-action@v3\`
4. Smoke-test the live Worker via JSON-RPC \`tools/list\` — fails the job if either expected tool (\`search_fliplet_docs\`, \`fetch_fliplet_doc\`) doesn't appear in the response

## ⚠️ Required setup BEFORE merging

Two repo secrets must exist or the first run will fail:

1. **\`CLOUDFLARE_API_TOKEN\`** — create at https://dash.cloudflare.com/profile/api-tokens with these permissions:
   - Account → Cloudflare Workers Scripts → Edit
   - Zone → Workers Routes → Edit (since the route is bound to \`developers.fliplet.com/mcp*\`)
   - Account Resources: include the Fliplet CF account
   - Zone Resources: include the \`fliplet.com\` zone
2. **\`CLOUDFLARE_ACCOUNT_ID\`** — visible in the CF dashboard sidebar on any account-scoped page

Add both at: https://github.com/Fliplet/fliplet-cli/settings/secrets/actions

The workflow deliberately does NOT trigger on changes to its own file, so merging this PR does not attempt a deploy. The first deploy will run the next time anything under \`docs/mcp-worker/\` changes (or when manually triggered via \`workflow_dispatch\`).

## Test plan

- [ ] Add the two repo secrets above
- [ ] Merge this PR — no workflow run expected
- [ ] Manually trigger the workflow once via \`workflow_dispatch\` (Actions tab → \"Deploy MCP Worker\" → \"Run workflow\") to confirm it works against the current master
- [ ] Confirm subsequent commits to \`docs/mcp-worker/\` auto-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)