### PR TITLE
feat(mcp): friendly landing page for browser visits to /mcp

### DIFF
--- a/.github/workflows/deploy-mcp-worker.yml
+++ b/.github/workflows/deploy-mcp-worker.yml
@@ -65,12 +65,17 @@ jobs:
           command: deploy
 
       - name: Smoke-test the live Worker
-        # Verify the deployed Worker actually responds with the expected
-        # tools list. CF Workers usually propagate within a few seconds, but
-        # we give it 15s of grace to avoid flaky failures right after deploy.
+        # Verify the deployed Worker on two code paths:
+        #   1. JSON-RPC tools/list — the protocol surface MCP clients use.
+        #   2. Browser GET (Accept: text/html) — the human-friendly landing
+        #      page; should return HTML with the server-card link.
+        # CF Workers usually propagate within a few seconds, but we give 15s
+        # of grace to avoid flaky failures right after deploy.
         run: |
           set -euo pipefail
           sleep 15
+
+          echo "=== Test 1: JSON-RPC tools/list ==="
           RESP=$(curl -fsX POST https://developers.fliplet.com/mcp \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json, text/event-stream' \
@@ -86,3 +91,21 @@ jobs:
             exit 1
           fi
           echo "OK: deployed Worker advertises both expected tools."
+
+          echo
+          echo "=== Test 2: Browser landing page ==="
+          # -D headers.txt captures response headers for Content-Type assertion.
+          BODY=$(curl -fs -D /tmp/headers.txt \
+            -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9' \
+            https://developers.fliplet.com/mcp)
+          CT=$(grep -i '^content-type:' /tmp/headers.txt | head -1 | tr -d '\r')
+          echo "Content-Type header: $CT"
+          if ! echo "$CT" | grep -qi 'text/html'; then
+            echo "::error::Smoke test failed — browser landing did not return text/html."
+            exit 1
+          fi
+          if ! echo "$BODY" | grep -q '/.well-known/mcp/server-card.json'; then
+            echo "::error::Smoke test failed — landing page missing server-card link."
+            exit 1
+          fi
+          echo "OK: browser landing page served as text/html with server-card link."

--- a/docs/mcp-worker/src/index.ts
+++ b/docs/mcp-worker/src/index.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { parseLlmsTxt, type DocEntry } from "./llms.ts";
 import { searchDocs } from "./search.ts";
 import { validateDocUrl } from "./ssrf.ts";
+import { isBrowserGet, renderLandingPage } from "./landing.ts";
 
 // === Config ===
 const DOCS_ORIGIN = "https://developers.fliplet.com";
@@ -199,6 +200,13 @@ export default {
   async fetch(request: Request, env: unknown, ctx: ExecutionContext): Promise<Response> {
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+    // Friendly explanatory page for plain browser visits. MCP-aware
+    // clients send Accept: text/event-stream (or .../json) — only
+    // browsers send text/html, so this branch never fires for legitimate
+    // protocol clients.
+    if (isBrowserGet(request)) {
+      return withCors(renderLandingPage());
     }
     try {
       const resp = await createMcpHandler(createServer())(request, env, ctx);

--- a/docs/mcp-worker/src/landing.ts
+++ b/docs/mcp-worker/src/landing.ts
@@ -1,0 +1,59 @@
+// Friendly HTML response for human visitors who hit the /mcp endpoint in
+// a browser. MCP-aware clients send `Accept: text/event-stream` (or
+// `application/json, text/event-stream`) per the Streamable HTTP spec —
+// browsers send `Accept: text/html,...`. Distinguishing them lets us
+// return a small explanatory page instead of the cryptic JSON-RPC
+// "Not Acceptable" error.
+
+const LANDING_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Fliplet docs MCP server</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+         max-width: 38rem; margin: 4rem auto; padding: 0 1.5rem; line-height: 1.55;
+         color: #1a1a1a; background: #fff; }
+  h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+  p { margin: 1rem 0; }
+  code { background: #f3f4f6; padding: 0.1rem 0.35rem; border-radius: 3px;
+         font-size: 0.9em; }
+  a { color: #0066cc; }
+  hr { border: 0; border-top: 1px solid #e5e7eb; margin: 2rem 0; }
+  .muted { color: #6b7280; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+<h1>Fliplet docs MCP server</h1>
+<p>This URL is the streamable-HTTP endpoint of a
+<a href="https://modelcontextprotocol.io">Model Context Protocol</a> server.
+It is designed to be configured into MCP-aware tooling, not browsed
+directly — that's why a plain browser visit returns a JSON-RPC
+<code>Not Acceptable</code> error.</p>
+<p>Endpoint: <code>https://developers.fliplet.com/mcp</code></p>
+<p>Server card with capabilities and transport details:<br>
+<a href="/.well-known/mcp/server-card.json">/.well-known/mcp/server-card.json</a></p>
+<hr>
+<p class="muted">Looking for the human-readable docs? Visit
+<a href="/">developers.fliplet.com</a>.</p>
+</body>
+</html>
+`;
+
+export function isBrowserGet(request: Request): boolean {
+  if (request.method !== "GET") return false;
+  const accept = request.headers.get("accept") ?? "";
+  return accept.toLowerCase().includes("text/html");
+}
+
+export function renderLandingPage(): Response {
+  return new Response(LANDING_HTML, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // Short cache: the page is static, but we may iterate the wording.
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/docs/mcp-worker/tests/landing.test.ts
+++ b/docs/mcp-worker/tests/landing.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { isBrowserGet, renderLandingPage } from "../src/landing.ts";
+
+describe("isBrowserGet", () => {
+  it("returns true for a GET with Accept: text/html", () => {
+    const req = new Request("https://x/mcp", {
+      method: "GET",
+      headers: { Accept: "text/html" },
+    });
+    expect(isBrowserGet(req)).toBe(true);
+  });
+
+  it("returns true for a typical browser Accept header", () => {
+    const req = new Request("https://x/mcp", {
+      method: "GET",
+      headers: {
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+      },
+    });
+    expect(isBrowserGet(req)).toBe(true);
+  });
+
+  it("returns false for an MCP client GET (Accept: text/event-stream only)", () => {
+    const req = new Request("https://x/mcp", {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(isBrowserGet(req)).toBe(false);
+  });
+
+  it("returns false for an MCP client GET (Accept: application/json, text/event-stream)", () => {
+    const req = new Request("https://x/mcp", {
+      method: "GET",
+      headers: { Accept: "application/json, text/event-stream" },
+    });
+    expect(isBrowserGet(req)).toBe(false);
+  });
+
+  it("returns false for any POST regardless of Accept", () => {
+    const req = new Request("https://x/mcp", {
+      method: "POST",
+      headers: { Accept: "text/html" },
+    });
+    expect(isBrowserGet(req)).toBe(false);
+  });
+
+  it("returns false when Accept is missing", () => {
+    const req = new Request("https://x/mcp", { method: "GET" });
+    expect(isBrowserGet(req)).toBe(false);
+  });
+
+  it("is case-insensitive on the Accept value", () => {
+    const req = new Request("https://x/mcp", {
+      method: "GET",
+      headers: { Accept: "TEXT/HTML" },
+    });
+    expect(isBrowserGet(req)).toBe(true);
+  });
+});
+
+describe("renderLandingPage", () => {
+  it("returns 200 OK with HTML Content-Type", async () => {
+    const resp = renderLandingPage();
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toMatch(/^text\/html/);
+  });
+
+  it("includes the server-card link and the canonical endpoint", async () => {
+    const resp = renderLandingPage();
+    const body = await resp.text();
+    expect(body).toContain("/.well-known/mcp/server-card.json");
+    expect(body).toContain("https://developers.fliplet.com/mcp");
+  });
+
+  it("explains why a plain browser visit returns Not Acceptable", async () => {
+    const resp = renderLandingPage();
+    const body = await resp.text();
+    expect(body).toMatch(/Not Acceptable/i);
+    expect(body).toMatch(/MCP/i);
+  });
+
+  it("sets a public Cache-Control with a non-zero max-age", () => {
+    const resp = renderLandingPage();
+    const cc = resp.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

A plain browser visit to https://developers.fliplet.com/mcp returns the cryptic JSON-RPC error:

\`\`\`
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Not Acceptable: Client must accept text/event-stream"},"id":null}
\`\`\`

Spec-compliant (MCP Streamable HTTP requires the client to advertise \`text/event-stream\` in Accept), but unhelpful to anyone who clicks a link to the endpoint or stumbles onto it.

This PR detects plain browser GETs (method GET + Accept includes \`text/html\`) at the worker entry and returns a small explanatory HTML page covering:

- what the endpoint is (an MCP streamable-HTTP server)
- why a direct browser visit doesn't work
- where to find the server card with capabilities and transport
- where the human-readable docs live

MCP-aware clients send \`Accept: text/event-stream\` (or the JSON-stream variant) — they don't include \`text/html\` — so this branch never fires for legitimate protocol traffic.

## Implementation

- \`src/landing.ts\` — two pure functions (\`isBrowserGet\`, \`renderLandingPage\`) so they can be unit-tested in Node without loading the Workers-only \`agents/mcp\` module.
- \`src/index.ts\` — early-returns the landing response before the MCP handler runs.
- \`tests/landing.test.ts\` — 11 new tests covering the predicate truth table (browser, MCP client, missing Accept, case-insensitivity, POST overrides) and the response shape (status, Content-Type, body content, Cache-Control).
- \`.github/workflows/deploy-mcp-worker.yml\` — smoke test now verifies BOTH paths after deploy: existing JSON-RPC \`tools/list\` AND new browser landing. If either regresses, the deploy job fails.

## Test plan

- [x] Unit tests: 31/31 pass (was 20/20)
- [x] Typecheck clean
- [ ] Post-merge: workflow auto-deploys; smoke test verifies both paths
- [ ] Post-merge manual: \`curl -sH 'Accept: text/html' https://developers.fliplet.com/mcp\` returns the HTML landing
- [ ] Post-merge manual: \`curl -sH 'Accept: application/json, text/event-stream' -X POST https://developers.fliplet.com/mcp -d '{...}'\` still returns \`tools/list\` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)