### PR TITLE
docs(v3): bring V3 reference docs onto master from origin/development

### DIFF
--- a/docs/API/v3/analytics.md
+++ b/docs/API/v3/analytics.md
@@ -1,0 +1,156 @@
+---
+description: V3 app analytics and event tracking. Page views are tracked automatically by the fliplet-analytics-spa runtime; this doc covers what you get for free and when to add event() calls for intent-bearing user actions.
+---
+
+# V3 app analytics and event tracking
+
+V3 apps get page-view tracking, session tracking, and device tracking for free — you don't need to wire any of it up. What you **do** need to add are `Fliplet.App.Analytics.event(...)` calls for meaningful user interactions that can't be inferred from a route change: form submissions, CTA clicks, flow completions, error acknowledgments.
+
+This doc tells you what's automatic, what to add, and how to keep event taxonomy clean enough that the analytics dashboards stay readable at scale.
+
+## Contents
+
+- [What you get for free](#what-you-get-for-free)
+- [What to add — custom events](#what-to-add--custom-events)
+- [Taxonomy — category, action, label](#taxonomy--category-action-label)
+- [Worked examples](#worked-examples)
+- [What **not** to track](#what-not-to-track)
+- [Related](#related)
+
+## What you get for free
+
+The `fliplet-analytics-spa` runtime library is preloaded on every V3 app and fires a `pageView` on every client-side route change. No code from the app is required.
+
+What it covers:
+
+- **Initial page load** — one `pageView` when `Fliplet.ready()` resolves.
+- **Client-side navigation** — one `pageView` on every `history.pushState` / `history.replaceState` (from any framework), plus `popstate` (back/forward) and `hashchange`. Consecutive navigations to the same URL are de-duped.
+- **Sessions** — the core analytics session (rotates every 30 minutes, per user) is managed by `fliplet-core`.
+- **Device / platform context** — `_platform`, `_os`, `_userEmail`, `_analyticsSessionId`, `_pageId`, `_pageTitle` are added to every event by the core tracker.
+
+Each auto `pageView` payload includes:
+
+| Field | Example | Notes |
+| --- | --- | --- |
+| `_pageTitle` | `/orders/:id` | Matched route pattern from the V3 manifest; falls back to raw path if no pattern matches. |
+| `_route` | `/orders/:id` | Same as `_pageTitle`, reserved for future payload enrichment. |
+| `_routeRaw` | `/orders/123?ref=email#top` | Actual URL including query and hash. |
+| `_routeParams` | `{ id: "123" }` | Params extracted from the pattern. |
+| `_routeName` | `"Order"` | `name` from the manifest route entry (if set). |
+
+Because page views are automatic, **do not call `Fliplet.App.Analytics.pageView(...)` yourself** from V3 app code. You'll double-count and pollute the pattern-matching.
+
+## What to add — custom events
+
+Use `Fliplet.App.Analytics.event(...)` for user-intent signals that can't be inferred from the URL. A rule of thumb: if a product manager would ask "how many people did X", X is probably an event.
+
+```js
+Fliplet.App.Analytics.event({
+  category: 'contact-form',
+  action: 'submit',
+  label: 'support-request'
+});
+```
+
+Good candidates:
+
+- Form submissions (with the form's name as `label`).
+- Primary CTAs — "Sign up", "Request demo", "Add to cart".
+- Flow completions — e.g. the user reaches the "thank you" step of a checkout.
+- Error acknowledgments — the user clicks "retry" or dismisses an error toast.
+- Feature toggles — user opens a filter panel, switches tabs into a rarely-used view.
+
+Poor candidates (skip these):
+
+- Scroll position, hover, focus / blur — too noisy, high cardinality, rarely answer a business question.
+- Anything tied to route changes — page views cover this.
+- Keystrokes or character-by-character input — always noise.
+
+## Taxonomy — category, action, label
+
+Events are aggregated in the dashboards by these three fields. Keep them disciplined or the dashboards become unreadable.
+
+- **`category`** — a stable, bounded namespace. Treat it like a table name. Examples: `'contact-form'`, `'onboarding'`, `'cart'`. Don't use free-form strings like `'Tracking user clicks on button 3'`.
+- **`action`** — a verb describing what happened. Examples: `'submit'`, `'click'`, `'complete'`, `'dismiss'`, `'retry'`. Past-tense is fine (`'submitted'`), just be consistent.
+- **`label`** — the specific instance, bounded. Examples: `'support-request'`, `'step-3'`, `'paywall'`. Never put PII here — no emails, phone numbers, names, user IDs, auth tokens, or free-form user input.
+
+Cardinality rule: `category` × `action` × `label` should produce at most a few hundred unique combinations per app. If a value is effectively unbounded (e.g. per-user IDs), it does not belong in the analytics payload — query the data source instead.
+
+## Worked examples
+
+### Good — form submission on a contact form
+
+```js
+document.querySelector('#contact-form').addEventListener('submit', function() {
+  Fliplet.App.Analytics.event({
+    category: 'contact-form',
+    action: 'submit',
+    label: 'support-request'
+  });
+});
+```
+
+### Good — checkout flow completion
+
+```js
+function onOrderConfirmed(order) {
+  Fliplet.App.Analytics.event({
+    category: 'checkout',
+    action: 'complete',
+    label: order.plan // 'starter' | 'pro' | 'enterprise' — bounded set
+  });
+}
+```
+
+### Good — user dismisses an error toast
+
+```js
+toast.on('dismiss', function() {
+  Fliplet.App.Analytics.event({
+    category: 'error',
+    action: 'dismiss',
+    label: toast.code // 'network', 'validation', 'unauthorized' — bounded
+  });
+});
+```
+
+### Bad — duplicating automatic page views
+
+```js
+// DO NOT do this. Page views are auto-tracked.
+router.afterEach(function(to) {
+  Fliplet.App.Analytics.pageView({ _pageTitle: to.path });
+});
+```
+
+### Bad — unbounded label containing PII
+
+```js
+// DO NOT do this. email is PII and has unbounded cardinality.
+Fliplet.App.Analytics.event({
+  category: 'login',
+  action: 'submit',
+  label: user.email
+});
+```
+
+### Bad — every scroll
+
+```js
+// DO NOT do this. Scroll noise drowns out real signals.
+window.addEventListener('scroll', function() {
+  Fliplet.App.Analytics.event({ category: 'scroll', action: 'move' });
+});
+```
+
+## What **not** to track
+
+- **PII** — never put emails, phone numbers, names, address fragments, auth tokens, or session IDs into `label` or any custom field you pass to `event(...)`. Core adds `_userEmail` automatically if the user is logged in; that's the sanctioned channel.
+- **Secrets** — same as PII: no auth tokens, no API keys, no one-time codes.
+- **High-cardinality identifiers** — per-record IDs, UUIDs, free-text user input. Aggregate these in data sources; they don't belong in analytics.
+- **Anything already on the URL** — auto page views already capture the route pattern and params. Don't add events that duplicate that information.
+
+## Related
+
+- [V3 routing](routing.md) — the route manifest that powers auto page-view pattern matching.
+- [Core analytics API](../core/analytics.md) — full reference for `Fliplet.App.Analytics`, including `track`, `get`, and `count`.

--- a/docs/API/v3/app-bootstrap.md
+++ b/docs/API/v3/app-bootstrap.md
@@ -1,0 +1,60 @@
+---
+description: The three constraints every V3 boot HTML must satisfy. Covers Fliplet.require.lazy for dependencies, Fliplet.Media.getContents for source files, and the Fliplet().then(...) init sequence. Framework-agnostic.
+---
+
+# V3 app bootstrap constraints
+
+A V3 app is a single HTML boot page that hosts the whole SPA. The page can use any framework (Vue, React, Svelte, vanilla JS, etc.), but it **must** satisfy three constraints so the Fliplet runtime, dependency loader, and media authentication work correctly.
+
+Each constraint maps to a concrete platform guarantee: (1) dependencies resolve through the Fliplet asset pipeline so versioning, caching, and per-environment injection work; (2) source files are fetched with signed media requests so private apps don't leak their screens; (3) the runtime registers its globals (`Fliplet.ENV`, `Fliplet.Router`, `Fliplet.Session`, etc.) before your framework mounts.
+
+<p class="warning">Skip any of these constraints and the app either fails at boot, or works in dev and breaks in production.</p>
+
+## 1. Fetch dependencies with `Fliplet.require.lazy`
+
+Any registered Fliplet dependency (Vue, React, Vue Router, etc.) **must** be loaded with `Fliplet.require.lazy(name)`. Never use `<script>` tags, `import`, or raw CDN URLs. These bypass the Fliplet asset pipeline and break versioning, caching, and dependency resolution.
+
+```js
+Fliplet.require.lazy('vue').then(function() {
+  // the 'vue' global is now available
+});
+```
+
+Chain multiple `.then()` calls to load several dependencies in sequence.
+
+## 2. Fetch source files with `Fliplet.Media.getContents`
+
+Source files for the app (component files, templates, JSON config, etc.) live in the app's media library. Their contents **must** be fetched at runtime with `Fliplet.Media.getContents(fileId)`. Never call `fetch()` on a media URL directly. Media URLs require authentication and will fail without it.
+
+```js
+Fliplet.Media.getContents(fileId).then(function(content) {
+  // content is the raw file source as a string
+});
+```
+
+The `fileId` is the **numeric `id`** of the file in the app's media library (returned by media upload APIs). It is never a URL.
+
+## 3. Init sequence
+
+The boot script must end with this call:
+
+```js
+Fliplet().then(function() {
+  // runtime is ready. Mount your framework or start your app here.
+});
+```
+
+`Fliplet().then(...)` waits for the Fliplet runtime to be fully ready before the app starts.
+
+<p class="warning">Skipping this breaks the boot.</p>
+
+## What's next: routing
+
+V3 uses History API routing driven by the manifest at `app.settings.v3`, accessed via `Fliplet.Router`. Hash routing is forbidden on every platform. For the full contract, per-framework examples, and the anti-patterns that break V3 apps, see [V3 routing](routing.md).
+
+## Related
+
+- [V3 routing](routing.md). History API contract, route manifest, and the forbidden-pattern reference.
+- [Fliplet Router JS API](fliplet-router.md). Method reference for `Fliplet.Router` (`getBasePath`, `getRouteManifest`, `resolveRoute`).
+- [V3 app settings convention](app-settings.md). Where `window.ENV.appSettings` comes from and the public/private key convention.
+- [Media JS APIs](../fliplet-media.md). Full reference for `Fliplet.Media.getContents` and related media calls.

--- a/docs/API/v3/app-settings.md
+++ b/docs/API/v3/app-settings.md
@@ -1,0 +1,148 @@
+---
+description: V3 app settings convention for storing public and private configuration. Covers the underscore prefix convention for editor-private settings.
+---
+
+# V3 App Settings Convention
+
+App settings in V3 use `app.settings` to store configuration for features like authentication, push notifications, and analytics. This page describes the naming convention that controls which settings are visible to the app runtime (preview and published apps) vs only to Studio editors.
+
+## The Underscore Convention
+
+Settings keys that start with `_` are **editor-private**. They are visible to Studio editors managing the app but are NOT included in the app runtime (preview iframe, published apps, bundled apps).
+
+| Key pattern | Who can read it | Example |
+|---|---|---|
+| `settingName` | App runtime + Studio + backend | `app.settings.saml2` (IdP URL, attribute mappings) |
+| `_settingName` | Studio editors + backend only | `app.settings._saml2` (IdP certificate) |
+
+The convention uses **top-level key namespacing**. All private settings for a feature go under a single `_feature` key, not mixed into the public feature key.
+
+## How It Works
+
+```
+app.settings = {
+  // Public settings — visible to the running app, Studio, and backend
+  saml2: {
+    idpUrl: 'https://idp.company.com/sso',
+    attributeMappings: { email: 'Email', name: 'Name' }
+  },
+
+  // Editor-private settings — visible to Studio editors, NOT to the running app
+  _saml2: {
+    idpCertificate: '-----BEGIN CERTIFICATE-----\nMIID...'
+  }
+}
+```
+
+When the app loads in the preview iframe or as a published app, `_saml2` is stripped from `window.ENV.appSettings`. The running app only sees:
+
+```js
+window.ENV.appSettings = {
+  saml2: {
+    idpUrl: 'https://idp.company.com/sso',
+    attributeMappings: { email: 'Email', name: 'Name' }
+  }
+  // _saml2 is NOT here
+}
+```
+
+Backend code (server-side passports, hooks, app actions) reads the full `app.settings` from the model — no filtering is applied server-side.
+
+## Usage Patterns
+
+### Reading Public Settings (App Runtime)
+
+```js
+// In a Vue component or app code — reads from the runtime environment
+var appSettings = window.ENV.appSettings || {};
+var saml2Config = appSettings.saml2;
+
+if (saml2Config && saml2Config.idpUrl) {
+  // SAML2 is configured — show SSO login button
+}
+```
+
+### Reading All Settings (Studio)
+
+```js
+// In Studio code (AppSettings.vue, tools, etc.) — reads full settings including _prefixed
+var response = await Fliplet.API.request({ url: 'v1/apps/' + appId + '/settings/' });
+var settings = response;
+
+// settings._saml2 is available here (editor context)
+var certificate = settings._saml2 && settings._saml2.idpCertificate;
+```
+
+### Saving Settings
+
+The `PUT /v1/apps/:id` endpoint performs a **shallow merge** on `settings`. Top-level keys in your request overwrite existing keys with the same name. Keys you don't include are preserved. Nested objects are replaced entirely, not deep-merged.
+
+```js
+// Save both public and private settings together.
+// This MERGES at the top level: saml2 and _saml2 are set/replaced,
+// but other top-level keys (customCSS, etc.) are preserved.
+await Fliplet.API.request({
+  url: 'v1/apps/' + appId,
+  method: 'PUT',
+  data: {
+    settings: {
+      saml2: {
+        idpUrl: 'https://idp.company.com/sso',
+        attributeMappings: { email: 'Email', name: 'Name' }
+      },
+      _saml2: {
+        idpCertificate: certificateText
+      }
+    }
+  }
+});
+
+// WARNING: This replaces the ENTIRE _saml2 object.
+// If _saml2 previously had { idpCertificate, otherField },
+// after this call it only has { idpCertificate }.
+// Always send the complete object for each top-level key.
+```
+
+## DO and DON'T
+
+```js
+// DO: Use top-level namespacing for private settings
+app.settings._saml2 = { idpCertificate: '...' };
+
+// DON'T: Mix private keys inside a public namespace
+app.settings.saml2 = { idpUrl: '...', _certificate: '...' };
+// The _ filter only operates on top-level keys. Nested _ keys are NOT filtered.
+
+// DO: Put related public and private config in sibling keys
+app.settings.push = { enabled: true };       // public
+app.settings._push = { apnsCertificate: '...' };  // editor-private
+
+// DON'T: Store secrets that should never leave the server in _ keys
+// _ keys are visible to Studio editors. For truly server-only secrets,
+// a future convention (__prefix) will be used. For now, use app widgets
+// or environment variables for server-only secrets.
+
+// DO: Check for existence before reading settings
+var saml2 = app.settings.saml2 || {};
+
+// DON'T: Assume settings exist — they may not be configured yet
+var url = app.settings.saml2.idpUrl; // Throws if saml2 is undefined
+```
+
+## When to Use Private Settings
+
+Use `_` prefix for settings that:
+- Contain credentials, certificates, or keys that app users should not see
+- Are only needed by Studio UI or backend processing, not by the running app
+- Would be a security risk if exposed in client-side JavaScript
+
+Examples:
+- `_saml2.idpCertificate` — X.509 certificate for SAML signature verification
+- `_push.apnsCertificate` — Apple Push Notification certificate (future)
+- `_analytics.apiKey` — Analytics service API key (future)
+
+## Related
+
+- [Session JS APIs](../fliplet-session.md) — session management
+- [V3 Authentication Patterns](auth.md) — auth flows for V3 apps
+- [App Security](../../App-security.md) — app-level access control

--- a/docs/API/v3/auth.md
+++ b/docs/API/v3/auth.md
@@ -1,0 +1,533 @@
+---
+description: V3 authentication patterns for email/password login, session management, logout, and protected routes. Use these patterns when building authentication flows in V3 apps.
+---
+
+# V3 Authentication Patterns
+
+Authentication in V3 apps uses the `Fliplet.Session` API to authenticate users against a Data Source. This page covers email/password login, session checks, logout, forgot-password, and protected route patterns specific to V3 single-page apps.
+
+For SAML2/SSO configuration, use the SAML2 tab in App Settings (not code). For email verification (passwordless), see the [Email Verification docs](../components/email-verification.md). For the full Session API reference, see [Session JS APIs](../fliplet-session.md).
+
+## Prerequisites
+
+- A Data Source containing user records with at least `Email` and `Password` columns
+- Security rules configured on the Data Source (see [Data Source Security](../../Data-source-security.md))
+- The `fliplet-datasources` dependency added to your app
+
+## Email/Password Login
+
+### Basic Login
+
+Authenticate a user against a Data Source using `Fliplet.Session.authorize()`. This creates a server-side session that persists across page navigations.
+
+```js
+async function loginUser(email, password, dataSourceId) {
+  try {
+    const session = await Fliplet.Session.authorize({
+      passport: 'dataSource',
+      dataSourceId: dataSourceId,
+      where: {
+        Email: email,
+        Password: password
+      }
+    });
+
+    // session.entries.dataSource.data contains the matched user record
+    // e.g., { Email: 'user@company.com', Name: 'Jane Smith', Role: 'Editor' }
+    const user = session.entries.dataSource.data;
+
+    console.log('Logged in as:', user.Email);
+
+    return session;
+  } catch (error) {
+    // Common errors:
+    // - "Unauthorized" — email or password does not match any record
+    // - Network errors — device is offline
+    console.error('Login failed:', error.message || error);
+    throw error;
+  }
+}
+```
+
+**Parameters for `Fliplet.Session.authorize()`:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `passport` | String | Yes | Must be `'dataSource'` for email/password login |
+| `dataSourceId` | Number | Yes | The ID of the Data Source containing user records |
+| `where` | Object | Yes | Field-value pairs to match. Typically `{ Email, Password }` |
+
+**Returns:** `Promise<Session>` — the session object with `entries.dataSource.data` containing the matched user record.
+
+**Errors:** Throws if credentials don't match or if the network request fails. The error does NOT reveal whether the email or password was wrong (security best practice).
+
+### Login Screen Vue Component
+
+A complete login screen as a Vue SFC for V3 apps:
+
+```html
+<template>
+  <div class="login-screen">
+    <div class="login-card">
+      <h1>Sign In</h1>
+      <form @submit.prevent="handleLogin">
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input
+            id="email"
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            placeholder="you@company.com"
+          />
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input
+            id="password"
+            v-model="password"
+            type="password"
+            required
+            autocomplete="current-password"
+          />
+        </div>
+        <p v-if="errorMessage" class="error-text">{{ errorMessage }}</p>
+        <button type="submit" :disabled="isLoading">
+          {{ isLoading ? 'Signing in...' : 'Sign In' }}
+        </button>
+      </form>
+      <p class="forgot-link">
+        <a href="#" @click.prevent="$router.push('/forgot-password')">Forgot password?</a>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+// Replace with the actual Data Source ID for your users table
+var USERS_DATA_SOURCE_ID = 123456;
+
+export default {
+  data: function() {
+    return {
+      email: '',
+      password: '',
+      errorMessage: '',
+      isLoading: false
+    };
+  },
+  methods: {
+    handleLogin: async function() {
+      this.errorMessage = '';
+      this.isLoading = true;
+
+      try {
+        await Fliplet.Session.authorize({
+          passport: 'dataSource',
+          dataSourceId: USERS_DATA_SOURCE_ID,
+          where: {
+            Email: this.email,
+            Password: this.password
+          }
+        });
+
+        // Login successful — navigate to the home screen
+        this.$router.push('/home');
+      } catch (error) {
+        this.errorMessage = 'Invalid email or password. Please try again.';
+      } finally {
+        this.isLoading = false;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.login-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 20px;
+}
+.login-card {
+  width: 100%;
+  max-width: 400px;
+}
+.form-group {
+  margin-bottom: 16px;
+}
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.form-group input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 16px;
+}
+.error-text {
+  color: #dc3545;
+  font-size: 14px;
+}
+button[type="submit"] {
+  width: 100%;
+  padding: 12px;
+  background: #4A90D9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 16px;
+  cursor: pointer;
+}
+button[type="submit"]:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.forgot-link {
+  text-align: center;
+  margin-top: 16px;
+}
+</style>
+```
+
+## Session Check
+
+Check whether the user is logged in. Use this in your App shell component or route guards to protect screens.
+
+```js
+async function isLoggedIn() {
+  try {
+    var session = await Fliplet.User.getCachedSession();
+
+    // getCachedSession returns the locally cached session (works offline).
+    // session.entries.dataSource exists if the user logged in via email/password.
+    return !!(session && session.entries && session.entries.dataSource);
+  } catch (error) {
+    return false;
+  }
+}
+```
+
+`Fliplet.User.getCachedSession()` is fast and works offline because it reads from local storage. Use it for UI decisions (show/hide content). For server-verified session checks, use `Fliplet.Session.get()` instead (requires network).
+
+### Get the Logged-In User's Data
+
+```js
+async function getCurrentUser() {
+  var session = await Fliplet.User.getCachedSession();
+
+  if (!session || !session.entries || !session.entries.dataSource) {
+    return null; // Not logged in
+  }
+
+  // Returns all columns from the user's Data Source record
+  // e.g., { Email: 'jane@company.com', Name: 'Jane Smith', Role: 'Editor' }
+  return session.entries.dataSource.data;
+}
+```
+
+## Logout
+
+Clear the session and redirect to the login screen. V3 uses History API routing on every platform, so redirect via your router (or `history.pushState` + `Fliplet.Router.getBasePath()`) — never `window.location.hash`. See [V3 Routing](routing.md) for the full contract.
+
+```js
+// Called from a component that has a router instance in scope.
+async function logout(router) {
+  await Fliplet.Session.logout('dataSource');
+
+  router.push('/login');
+}
+```
+
+If you don't have a router handy (e.g., a framework-agnostic helper), use the History API directly:
+
+```js
+async function logout() {
+  await Fliplet.Session.logout('dataSource');
+
+  history.pushState({}, '', Fliplet.Router.getBasePath() + '/login');
+  // Trigger your router's re-render. In vanilla setups, dispatch a popstate.
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+```
+
+`Fliplet.Session.logout('dataSource')` clears the dataSource passport. To log out from all passport types (dataSource, saml2, flipletLogin), call `Fliplet.Session.logout()` with no arguments.
+
+## Protected Routes with Vue Router Guards
+
+In V3 apps using Vue Router, protect routes by checking the session before navigation. This section assumes the router was built per the V3 routing contract (History API, base path from `Fliplet.Router.getBasePath()`, routes from `Fliplet.Router.getRouteManifest()`). See the [Vue Router 4 example](routing.md#vue-router-4-vue-3) in the V3 Routing doc — or the sibling examples for other frameworks — before wiring the guard below.
+
+### In the App Shell (App.vue)
+
+Add a `beforeEach` guard to the router in your boot template's `initVueApp()` function. This does NOT go inside an SFC file. It goes in the boot HTML:
+
+```js
+// Inside initVueApp(), after creating the router:
+router.beforeEach(function(to, from, next) {
+  // Define which routes are public (accessible without login)
+  var publicRoutes = ['/login', '/forgot-password', '/reset-password'];
+
+  if (publicRoutes.indexOf(to.path) !== -1) {
+    return next(); // Public route — allow
+  }
+
+  // Check session for protected routes
+  Fliplet.User.getCachedSession().then(function(session) {
+    if (session && session.entries && session.entries.dataSource) {
+      next(); // Logged in — allow
+    } else {
+      next('/login'); // Not logged in — redirect to login
+    }
+  }).catch(function() {
+    next('/login'); // Error checking session — redirect to login
+  });
+});
+```
+
+### Route Configuration
+
+Define your routes so the login screen is accessible without authentication:
+
+```js
+routes: [
+  { path: '/', redirect: '/home' },
+  { path: '/login', name: 'Login', component: function() { return loadComponent(COMPONENT_FILES.Login); } },
+  { path: '/forgot-password', name: 'ForgotPassword', component: function() { return loadComponent(COMPONENT_FILES.ForgotPassword); } },
+  { path: '/home', name: 'Home', component: function() { return loadComponent(COMPONENT_FILES.Home); } },
+  { path: '/settings', name: 'Settings', component: function() { return loadComponent(COMPONENT_FILES.Settings); } }
+]
+```
+
+## Forgot Password
+
+Password reset uses the existing Data Source validation APIs. Code generation, storage, email delivery, and verification all happen server-side. The client orchestrates the UI steps.
+
+The flow uses three existing APIs:
+1. `dataSource.sendValidation()` — server generates a code, stores it, sends it via email
+2. `dataSource.validate()` — server verifies the code, marks the user as needing a password reset
+3. `Fliplet.Session.updateUserPassword()` — server updates the password
+
+**Do NOT build custom password reset logic.** These APIs handle code generation, expiry, and verification server-side. The client never sees the reset code.
+
+### Forgot Password Screen (Vue SFC)
+
+```html
+<template>
+  <div class="forgot-password-screen">
+    <div class="form-card">
+      <h1>Reset Password</h1>
+
+      <!-- Step 1: Enter email -->
+      <div v-if="step === 'email'">
+        <p>Enter your email address and we'll send you a verification code.</p>
+        <form @submit.prevent="sendCode">
+          <div class="form-group">
+            <label for="reset-email">Email</label>
+            <input id="reset-email" v-model="email" type="email" required />
+          </div>
+          <p v-if="errorMessage" class="error-text">{{ errorMessage }}</p>
+          <button type="submit" :disabled="isLoading">
+            {{ isLoading ? 'Sending...' : 'Send Code' }}
+          </button>
+        </form>
+      </div>
+
+      <!-- Step 2: Enter code -->
+      <div v-if="step === 'verify'">
+        <p>Enter the verification code sent to {{ email }}</p>
+        <form @submit.prevent="verifyCode">
+          <div class="form-group">
+            <label for="code">Verification Code</label>
+            <input id="code" v-model="code" type="text" required />
+          </div>
+          <p v-if="errorMessage" class="error-text">{{ errorMessage }}</p>
+          <button type="submit" :disabled="isLoading">
+            {{ isLoading ? 'Verifying...' : 'Verify Code' }}
+          </button>
+        </form>
+      </div>
+
+      <!-- Step 3: New password -->
+      <div v-if="step === 'reset'">
+        <p>Choose a new password.</p>
+        <form @submit.prevent="resetPassword">
+          <div class="form-group">
+            <label for="new-password">New Password</label>
+            <input id="new-password" v-model="newPassword" type="password" required minlength="8" />
+          </div>
+          <div class="form-group">
+            <label for="confirm-password">Confirm Password</label>
+            <input id="confirm-password" v-model="confirmPassword" type="password" required minlength="8" />
+          </div>
+          <p v-if="errorMessage" class="error-text">{{ errorMessage }}</p>
+          <button type="submit" :disabled="isLoading">
+            {{ isLoading ? 'Resetting...' : 'Reset Password' }}
+          </button>
+        </form>
+      </div>
+
+      <p class="back-link">
+        <a href="#" @click.prevent="$router.push('/login')">Back to Sign In</a>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+var USERS_DATA_SOURCE_ID = 123456; // Replace with your Users data source ID
+var EMAIL_COLUMN = 'Email';        // The column name for email in your data source
+var PASSWORD_COLUMN = 'Password';  // The column name for password in your data source
+
+export default {
+  data: function() {
+    return {
+      step: 'email',
+      email: '',
+      code: '',
+      newPassword: '',
+      confirmPassword: '',
+      errorMessage: '',
+      isLoading: false,
+      dataSource: null
+    };
+  },
+  methods: {
+    getDataSource: async function() {
+      if (!this.dataSource) {
+        this.dataSource = await Fliplet.DataSources.connect(USERS_DATA_SOURCE_ID);
+      }
+      return this.dataSource;
+    },
+    sendCode: async function() {
+      this.errorMessage = '';
+      this.isLoading = true;
+
+      try {
+        var ds = await this.getDataSource();
+        var where = {};
+        where[EMAIL_COLUMN] = this.email;
+
+        // Server generates a code, stores it on the entry, and sends it via email.
+        // Returns 204 regardless of whether the email exists (no information leak).
+        await ds.sendValidation({
+          type: 'email',
+          where: where
+        });
+
+        this.step = 'verify';
+      } catch (error) {
+        this.errorMessage = 'Something went wrong. Please try again.';
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    verifyCode: async function() {
+      this.errorMessage = '';
+      this.isLoading = true;
+
+      try {
+        var ds = await this.getDataSource();
+
+        // Server validates the code and marks the session for password reset.
+        // This also logs the user in temporarily so updateUserPassword works.
+        await ds.validate({
+          type: 'email',
+          where: {
+            code: this.code
+          },
+          requiresPasswordReset: true
+        });
+
+        this.step = 'reset';
+      } catch (error) {
+        this.errorMessage = 'Invalid or expired code. Please try again.';
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    resetPassword: async function() {
+      this.errorMessage = '';
+
+      if (this.newPassword !== this.confirmPassword) {
+        this.errorMessage = 'Passwords do not match.';
+        return;
+      }
+
+      if (this.newPassword.length < 8) {
+        this.errorMessage = 'Password must be at least 8 characters.';
+        return;
+      }
+
+      this.isLoading = true;
+
+      try {
+        // Server updates the password on the data source entry and logs out the user.
+        await Fliplet.Session.updateUserPassword({
+          newPassword: this.newPassword,
+          passwordColumn: PASSWORD_COLUMN
+        });
+
+        // Password updated — redirect to login
+        this.$router.push('/login');
+      } catch (error) {
+        this.errorMessage = 'Failed to reset password. Please try again.';
+      } finally {
+        this.isLoading = false;
+      }
+    }
+  }
+};
+</script>
+```
+
+**API Reference for the forgot-password flow:**
+
+| Step | Client calls | Server does |
+|---|---|---|
+| Send code | `dataSource.sendValidation({ type: 'email', where: { Email: '...' } })` | Generates code, stores on entry, sends email. Returns 204 (no info leak). |
+| Verify code | `dataSource.validate({ type: 'email', where: { code: '...' }, requiresPasswordReset: true })` | Validates code, checks expiry (24h default), creates temporary session. |
+| Reset password | `Fliplet.Session.updateUserPassword({ newPassword, passwordColumn })` | Updates password column on data source entry, logs out user. |
+
+This is the same flow the V2 login widget uses. All security-critical operations (code generation, validation, password storage) happen server-side.
+
+## Patterns — DO and DON'T
+
+```js
+// DO: Use Fliplet.Session.authorize() for email/password login
+await Fliplet.Session.authorize({ passport: 'dataSource', dataSourceId: id, where: { Email, Password } });
+
+// DON'T: Store session tokens in localStorage
+// localStorage is partitioned in cross-origin iframes (Studio preview).
+// Fliplet.Session handles storage internally.
+
+// DO: Use Fliplet.User.getCachedSession() for session checks (fast, works offline)
+var session = await Fliplet.User.getCachedSession();
+
+// DON'T: Use Fliplet.Session.get() for every session check
+// Session.get() makes a network request. Use getCachedSession() for UI decisions.
+
+// DO: Use Vue Router guards for protected routes (see above)
+// DON'T: Check the session inside every component's mounted() hook
+
+// DO: Use Fliplet.Session.logout('dataSource') for dataSource logouts
+// DON'T: Clear cookies or localStorage manually — the SDK handles cleanup
+
+// DO: Show generic "Invalid email or password" errors
+// DON'T: Reveal whether the email or password was wrong separately
+```
+
+## Related
+
+- [V3 Routing](routing.md) — base path, route manifest, `resolveRoute`, and post-login redirect pattern.
+- [V3 App Bootstrap](app-bootstrap.md) — the three boot-HTML constraints every V3 app must satisfy.
+- [Session JS APIs](../fliplet-session.md) — full session API reference
+- [Login Component](../components/login.md) — V2 login component hooks
+- [Email Verification](../components/email-verification.md) — passwordless login flow
+- [Data Source Security](../../Data-source-security.md) — security rules for user data sources
+- [App Security](../../App-security.md) — app-level access control rules

--- a/docs/API/v3/fliplet-router.md
+++ b/docs/API/v3/fliplet-router.md
@@ -1,0 +1,214 @@
+---
+description: Fliplet.Router JS API reference for V3 apps. Covers getBasePath, getRouteManifest, getRouteConfig, and resolveRoute including return shapes, reason codes, and rejection behavior.
+---
+
+# Fliplet Router JS API
+
+`Fliplet.Router` is the client-side routing helper for V3 SPA apps. It reads the route manifest from `app.settings.v3`, normalizes the base path for the current hosting context (slug-hosted web, Studio preview iframe, native shell), and performs server-ACL-backed access checks for each route.
+
+<p class="info"><code>Fliplet.Router</code> is available on V3 apps only and is auto-loaded at boot. It depends on <code>fliplet-core</code> (<code>Fliplet.Env</code>, <code>Fliplet.User</code>) and <code>fliplet-media</code> (<code>Fliplet.Media.getContents</code>).</p>
+
+For the full routing contract, per-framework integration examples, and forbidden patterns, see [V3 routing](routing.md). This page is the API reference only.
+
+## Contents
+
+- [Methods](#methods)
+  - [getBasePath()](#flipletroutergetbasepath)
+  - [getRouteManifest()](#flipletroutergetroutemanifest)
+  - [getRouteConfig(path)](#flipletroutergetrouteconfigpath)
+  - [resolveRoute(pathOrRoute)](#flipletrouterresolveroutepathorroute)
+- [Reason codes](#reason-codes)
+- [Manifest shape](#manifest-shape)
+- [Related](#related)
+
+## Methods
+
+### `Fliplet.Router.getBasePath()`
+
+Returns the base path used by the router's history mode, normalized with a trailing slash so string concatenation doesn't produce `//route`.
+
+**Returns:** `String`
+
+The value depends on the hosting context:
+
+| Context | Example value |
+|---|---|
+| Root-hosted web app | `/` |
+| Slug-hosted web app | `/my-slug/` |
+| Studio preview iframe | `/v1/apps/42/pages/99/preview/` |
+| Native shell | Computed by the shell at runtime |
+
+```js
+var base = Fliplet.Router.getBasePath();
+
+// Pass to Vue Router 4:
+var history = VueRouter.createWebHistory(base);
+
+// Pass to React Router 6:
+var router = ReactRouterDOM.createBrowserRouter(routes, { basename: base });
+```
+
+<p class="warning">Never hardcode <code>'/'</code>. Slug-hosted apps, preview iframes, and native shells all mount the SPA at a different base.</p>
+
+### `Fliplet.Router.getRouteManifest()`
+
+Returns the route manifest stored in `app.settings.v3`. Defaults are provided for every field so callers can use the return value without null checks.
+
+**Returns:** `Object` with the following properties:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `routes` | `Array<Object>` | `[]` | Route entries. See [Manifest shape](#manifest-shape). |
+| `defaultRoute` | `String` | `'/'` | Path to redirect to from `/`. |
+| `authRedirect` | `String` | `'/login'` | Path to redirect to when a route is denied. |
+
+```js
+var manifest = Fliplet.Router.getRouteManifest();
+
+manifest.routes.forEach(function(r) {
+  console.log(r.name, r.path, r.fileId, r.public);
+});
+
+console.log(manifest.defaultRoute); // '/home'
+console.log(manifest.authRedirect); // '/login'
+```
+
+### `Fliplet.Router.getRouteConfig(path)`
+
+Looks up a single route entry from the manifest by path. The lookup is path-based and normalizes leading slashes (`home` and `/home` match the same route).
+
+**Parameters:**
+
+| Name | Type | Description |
+|---|---|---|
+| `path` | `String` | Route path, with or without a leading slash. |
+
+**Returns:** `Object | undefined`. The matching route entry from `manifest.routes`, or `undefined` if no route matches.
+
+```js
+var route = Fliplet.Router.getRouteConfig('/home');
+
+if (route) {
+  console.log(route.fileId);   // 222
+  console.log(route.public);   // true
+} else {
+  // Path isn't in the manifest
+}
+```
+
+### `Fliplet.Router.resolveRoute(pathOrRoute)`
+
+Resolves a route to its access decision **and** its screen source. On success, `result.content` is the screen's source already loaded via `Fliplet.Media.getContents` — render it directly rather than re-fetching. The server's media ACL is the source of truth; this method either fast-fails when the outcome is known (no session, unknown route) or derives the decision from the server's 401/403 response.
+
+**Parameters:**
+
+| Name | Type | Description |
+|---|---|---|
+| `pathOrRoute` | `String \| Object` | A route path (string) or a route entry object from the manifest. |
+
+**Returns:** `Promise` that:
+
+- **Resolves** with an access decision (see shapes below).
+- **Rejects** with the underlying error on transient or infra failures (network errors, 5xx responses) so callers can show an error UI instead of redirecting silently.
+
+**Resolution shape on success:**
+
+```js
+{
+  allowed: true,
+  content: '<!-- raw screen HTML/JS source -->',
+  route: { name: 'Home', path: '/home', fileId: 222, public: true }
+}
+```
+
+**Resolution shape on denial:**
+
+```js
+{
+  allowed: false,
+  redirectTo: '/login',      // manifest.authRedirect
+  reason: 'no-session',      // see Reason codes below
+  status: 401                // only present when reason is 'media-denied'
+}
+```
+
+<p class="warning">Don't call <code>Fliplet.Media.getContents(fileId)</code> yourself. <code>resolveRoute</code> already does this internally and returns the content in <code>result.content</code>. A second fetch duplicates the round trip, can race with the access check, and fails outright on private media where auth headers aren't applied.</p>
+
+**Example:**
+
+```js
+Fliplet.Router.resolveRoute('/my-account').then(function(result) {
+  if (!result.allowed) {
+    // Redirect to the auth screen (or wherever the server says)
+    navigate(result.redirectTo);
+    return;
+  }
+
+  // Mount the screen using result.content
+  mountScreen(result.content, result.route);
+}, function(err) {
+  // Transient failure (network, 5xx). Show an error UI rather than redirecting.
+  showErrorScreen(err);
+});
+```
+
+**Passing a route object instead of a path:**
+
+If you already have a route entry from the manifest, you can pass it directly to skip the path lookup:
+
+```js
+var manifest = Fliplet.Router.getRouteManifest();
+var route = manifest.routes[0];
+
+Fliplet.Router.resolveRoute(route).then(function(result) {
+  // ...
+});
+```
+
+## Reason codes
+
+When `resolveRoute` resolves with `allowed: false`, the `reason` property indicates why. Handle each case explicitly.
+
+| `reason` | Triggered when | `redirectTo` | `status` |
+|---|---|---|---|
+| `unknown-route` | The path doesn't match any manifest entry, or the matched entry has no `fileId`. | `manifest.authRedirect` | Not set |
+| `no-session` | The route is non-public and `Fliplet.User.getCachedSession()` returned no session. | `manifest.authRedirect` | Not set |
+| `media-denied` | The server returned `401` or `403` when fetching the screen source. | `manifest.authRedirect` | `401` or `403` |
+
+<p class="warning">The manifest's <code>public: true</code> flag is advisory. It just lets the client skip a known-401 round trip. Flipping <code>public: true</code> in the manifest without updating the media file's access rule grants no access; the server still returns 401 and <code>resolveRoute</code> resolves with <code>reason: 'media-denied'</code>.</p>
+
+Transient errors (network failures, 5xx responses) do not resolve with a reason. They **reject** the Promise with the underlying error so you can distinguish "user can't access this" from "infrastructure is broken".
+
+## Manifest shape
+
+The manifest is stored at `app.settings.v3` and emitted to the runtime via `window.ENV.appSettings`. See [V3 app settings convention](app-settings.md) for how settings are stored and filtered.
+
+```json
+{
+  "routes": [
+    { "name": "Home",      "path": "/home",       "fileId": 222, "public": true },
+    { "name": "Login",     "path": "/login",      "fileId": 444, "public": true },
+    { "name": "MyAccount", "path": "/my-account", "fileId": 333 }
+  ],
+  "defaultRoute": "/home",
+  "authRedirect": "/login"
+}
+```
+
+Each route entry has the following properties:
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `name` | `String` | Yes | Display name for the route. Used in Studio UI and as a named route in framework routers. |
+| `path` | `String` | Yes | URL path the route is mounted at. Must begin with `/`. |
+| `fileId` | `Number` | Yes | Numeric `id` of the media file holding the screen source. `resolveRoute` fetches this via `Fliplet.Media.getContents`. |
+| `public` | `Boolean` | No | If `true`, the client skips the session check before fetching media. Defaults to `false`. Advisory only; the server media ACL is still enforced. |
+
+Update the manifest via the App Settings API (`PUT /v1/apps/:id` with `settings.v3`) or the Studio routing UI whenever you add or remove a user-visible route.
+
+## Related
+
+- [V3 routing](routing.md). Full routing contract, per-framework examples, forbidden patterns, and post-login redirect.
+- [V3 app bootstrap constraints](app-bootstrap.md). Three constraints every V3 boot HTML must satisfy.
+- [V3 app settings convention](app-settings.md). Where the route manifest is stored (`app.settings.v3`).
+- [Media JS APIs](../fliplet-media.md). `Fliplet.Media.getContents` details.

--- a/docs/API/v3/frameworks/alpine.md
+++ b/docs/API/v3/frameworks/alpine.md
@@ -1,0 +1,73 @@
+---
+description: Constraints for building V3 apps in Alpine.js. Alpine is attribute-driven HTML with no build step, so it maps cleanly to the V3 runtime. Covers x-init timing relative to Fliplet().then and History API routing pairing.
+---
+
+# V3 Alpine.js apps
+
+Alpine fits V3 well because it's attribute-driven HTML with no compile step. Components are just `<div x-data="{...}">` — the kind of markup V3 already evaluates natively. Best fit: form-heavy UIs, settings panels, and single-page CRUD where you'd otherwise reach for jQuery.
+
+## Loading the framework
+
+Add `alpinejs` via `add_dependencies`, then:
+
+```js
+const Alpine = await Fliplet.require.lazy('alpinejs');
+Alpine.start();
+```
+
+**Call `Alpine.start()` inside your `Fliplet().then(...)` callback**, not at module load. Alpine scans the DOM and initializes `x-data` components when it starts — if it starts before the Fliplet runtime resolves, any `x-init` or `x-data` expression that calls `Fliplet.*` will error.
+
+## Features that need a build step
+
+None that Alpine itself requires. The generic V3 constraints still apply:
+
+- No bare ESM `import` across uploaded source files — use `Fliplet.require.lazy` for external deps.
+- No TypeScript.
+- No CSS preprocessing.
+
+## Wiring to Fliplet.Router
+
+Alpine has no router. Pair it with History API routing the same way as vanilla JS:
+
+```js
+function goTo(path) {
+  history.pushState({}, '', Fliplet.Router.getBasePath() + path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+```
+
+Use `Fliplet.Router.resolveRoute(path)` in your `popstate` handler. See [V3 routing](../routing.md).
+
+## Binding Fliplet.Media.authenticate
+
+Compute the authenticated URL inside `x-init` or a method, then set a data property:
+
+```html
+<img x-data="{ src: '' }"
+     x-init="Fliplet.Media.authenticate(rawUrl).then(u => src = u)"
+     :src="src">
+```
+
+The `:src="src"` binding updates once the promise resolves. Do not try `:src="Fliplet.Media.authenticate(rawUrl)"` — that binds the Promise, not the URL.
+
+## Common errors
+
+| Symptom in `get_preview_logs('errors')` | Cause | Fix |
+|---|---|---|
+| `Alpine Expression Error: Fliplet is not defined` | `Alpine.start()` called before `Fliplet()` resolved | Move `Alpine.start()` inside `Fliplet().then(...)` |
+| `<img>` renders with a Promise in `src` | Using `Fliplet.Media.authenticate(url)` directly in `:src` | Resolve into a state variable first (see above) |
+| Components don't react | `Alpine.start()` called before the target markup was in the DOM | Ensure the screen source is inserted before Alpine starts, or use `Alpine.initTree(el)` on newly inserted markup |
+
+## DO / DON'T
+
+- DO call `Alpine.start()` inside `Fliplet().then(...)`.
+- DO resolve authenticated URLs into a reactive `x-data` field before binding.
+- DO pair Alpine with History API routing from `Fliplet.Router.getBasePath()`.
+- DON'T bind a Promise directly into an attribute (`:src`, `:href`).
+- DON'T use hash-based navigation — rejected by lint.
+
+## Related
+
+- [V3 app bootstrap](../app-bootstrap.md)
+- [V3 routing](../routing.md)
+- [V3 framework overview](overview.md)

--- a/docs/API/v3/frameworks/overview.md
+++ b/docs/API/v3/frameworks/overview.md
@@ -1,0 +1,47 @@
+---
+description: Picking a frontend framework for a V3 app. Lists the runtime constraints every framework must cope with (no build step, no bundler, no transpile) and compares Vue, React, Alpine, and vanilla JS against them.
+---
+
+# V3 framework guide — picking and setup
+
+V3 apps run **without a build step**. Source files are uploaded to the media library and fetched at runtime via `Fliplet.Media.getContents`. Dependencies are resolved through `Fliplet.require.lazy`, not `import`. This changes which framework features work and which quietly fail.
+
+Fetch the per-framework doc (`v3-framework-vue`, `v3-framework-react`, etc.) before scaffolding. This doc is for picking.
+
+## The runtime constraints (apply to every framework)
+
+| Constraint | What it means |
+|---|---|
+| No transpile | JSX, TSX, and any other syntax the browser can't parse natively will throw `SyntaxError: Unexpected token`. |
+| No bundler | Bare ESM imports (`import x from 'vue'`) fail. Dependencies must come from `Fliplet.require.lazy(name)` or a full CDN URL added via `add_dependencies`. |
+| No CSS preprocessing | No CSS Modules, no Sass, no PostCSS. Styles are plain CSS inlined in `<style>` or component HTML. |
+| Hash routing is rejected | `hashchange`, `window.location.hash`, `createWebHashHistory`, `HashRouter`, and `href="#/..."` are all rejected by the boot-HTML lint. History API only. See [V3 routing](../routing.md). |
+| Preloaded libraries | jQuery, Bootstrap CSS, Lodash, Moment, Animate.css, and fliplet-media are always available — never add them as dependencies. |
+
+## Framework comparison
+
+| Framework | Needs compile? | Router support | Good fit for |
+|---|---|---|---|
+| Vanilla JS | No | History API (manual) | Single-screen apps, very simple flows |
+| Vue 3 | No (runtime-compiler build) | Vue Router 4 (`createWebHistory`) | Multi-screen apps with reactive state |
+| React | **Yes, for JSX** | React Router 6 (`basename`) | Users who asked for React; otherwise prefer Vue |
+| Alpine.js | No | Pair with vanilla History API | Form-heavy, attribute-driven UIs |
+
+## Picking rules
+
+Default order when the user hasn't expressed a preference:
+
+1. **One screen, no forms**: vanilla JS
+2. **Multi-screen, reactive state**: Vue 3 — best balance of no-build ergonomics and features
+3. **Form-heavy single-page CRUD**: Alpine.js
+4. **User explicitly asked for React**: React, via `htm` or `React.createElement` (see `v3-framework-react`)
+
+## What to fetch next
+
+After picking, call `get_fliplet_docs('v3-framework-<name>')` for the specific constraints. Every per-framework doc covers: loading the framework, features that need a build step (and what to do instead), wiring to `Fliplet.Router`, binding `Fliplet.Media.authenticate`, common errors, and DO/DON'T.
+
+## Related
+
+- [V3 app bootstrap](../app-bootstrap.md) — the three boot constraints every app must satisfy regardless of framework
+- [V3 routing](../routing.md) — History API contract, route manifest, forbidden-pattern reference
+- [V3 authentication patterns](../auth.md) — session, login, protected routes

--- a/docs/API/v3/frameworks/react.md
+++ b/docs/API/v3/frameworks/react.md
@@ -1,0 +1,115 @@
+---
+description: Constraints for building V3 apps in React. Covers the JSX transpilation problem (the #1 cause of first-deploy failures) with three alternatives, React Router 6 basename wiring to Fliplet.Router.getBasePath, and the no-build-step limits on CSS modules and TSX.
+---
+
+# V3 React apps
+
+React works in V3, but it needs more thought than Vue because **JSX cannot run without a transpiler**. The browser will throw `SyntaxError: Unexpected token '<'` the first time it sees JSX in an uploaded source file. The V3 runtime does not transpile.
+
+## Loading the framework
+
+Add `react` and `react-dom` via `add_dependencies` with `lazy: true`, then:
+
+```js
+await Fliplet.require.lazy('react');
+await Fliplet.require.lazy('react-dom');
+const React = window.React;
+const ReactDOM = window.ReactDOM;
+```
+
+`Fliplet.require.lazy(name)` resolves once the UMD bundle has executed; the module itself lands on `window` (`window.React`, `window.ReactDOM`, `window.htm`, `window.ReactRouterDOM`). Read it off `window` after the `await` — assigning the awaited value directly gives you the URL string, not the module.
+
+For routing, `react-router-dom`'s UMD bundle is not self-contained — it delegates its named exports (`Navigate`, `Outlet`, `useNavigate`, `useLocation`, `Link`, `createBrowserRouter`, …) to two peer packages that must be loaded first as globals:
+
+```js
+await Fliplet.require.lazy('@remix-run/router');  // sets window.RemixRouter
+await Fliplet.require.lazy('react-router');       // sets window.ReactRouter, needs RemixRouter
+await Fliplet.require.lazy('react-router-dom');   // sets window.ReactRouterDOM, needs the two above
+const ReactRouterDOM = window.ReactRouterDOM;
+```
+
+Add all three via `add_dependencies` with `lazy: true` and match the minor versions across them (e.g. `react-router-dom@6.26.x` + `react-router@6.26.x` + `@remix-run/router@1.19.x`). Skipping `react-router` or `@remix-run/router` leaves `ReactRouterDOM.Navigate` etc. as throwing getters that fail at first render.
+
+Adding them via `add_dependencies` is not enough — listing a package as a lazy dep only registers the URL. The boot script must also `await Fliplet.require.lazy(name)` on all three (in the order above) before accessing any `ReactRouterDOM.*` export, or you'll hit `ReactRouterDOM.createBrowserRouter is not a function`.
+
+## Features that need a build step
+
+The big one:
+
+### JSX
+
+JSX is not valid JavaScript. Three ways to write React in V3 without a transpiler:
+
+| Option | Cost | When to use |
+|---|---|---|
+| **`htm` tagged templates** | ~1KB | **Recommended.** Looks nearly identical to JSX; runs in the browser. Load via `Fliplet.require.lazy('htm')`. |
+| `React.createElement` | 0 | Verbose but dependency-free. Fine for small apps or one-off components. |
+| `@babel/standalone` | ~2MB, slow first boot | Only if the user explicitly insists on raw JSX. Add via `add_dependencies` with the CDN URL and lazy-load. Adds 1–2 seconds to app boot. |
+
+Prefer `htm` unless the user has a specific reason to override.
+
+### Others
+
+| Feature | Why it fails | Do this instead |
+|---|---|---|
+| `.tsx`, `.ts` | No TypeScript transpiler | Plain JavaScript |
+| Bare ESM imports (`import React from 'react'`) | No bundler resolves the specifier | `Fliplet.require.lazy('react')` |
+| CSS Modules (`styles.module.css`) | No bundler to process them | Inline `<style>` or a plain `.css` uploaded as a media file |
+| `import './styles.css'` | Same | Upload the CSS as a media file and inject a `<link>` with the authenticated URL |
+
+## Wiring to Fliplet.Router
+
+Full contract in [V3 routing](../routing.md). React-specific: pass `basename` when creating the router:
+
+```js
+const router = createBrowserRouter(routes, {
+  basename: Fliplet.Router.getBasePath()
+});
+```
+
+`HashRouter` is rejected by the boot-HTML lint (rule `hash-router-react`). Build routes from `Fliplet.Router.getRouteManifest()`; route loaders should call `Fliplet.Router.resolveRoute(path)`.
+
+## Binding Fliplet.Media.authenticate
+
+Authenticated URLs are async. Resolve them in `useEffect` and store in state:
+
+```js
+const [logoSrc, setLogoSrc] = useState('');
+useEffect(() => {
+  Fliplet.Media.authenticate(rawUrl).then(setLogoSrc);
+}, [rawUrl]);
+```
+
+Then `<img src={logoSrc} />`. Calling `Fliplet.Media.authenticate` at module scope gives you a Promise, not a URL — the `src` will render empty.
+
+## Common errors
+
+| Symptom in `get_preview_logs('errors')` | Cause | Fix |
+|---|---|---|
+| `SyntaxError: Unexpected token '<'` | Raw JSX in an uploaded source file | Switch to `htm` tagged templates or `React.createElement` |
+| `Cannot use import statement outside a module` | Bare ESM `import` | Use `Fliplet.require.lazy` |
+| `ReferenceError: React is not defined` inside a component | Component file ran before `react` resolved | Load dependencies in the boot HTML and pass React into component factories, or use `Fliplet.require.lazy` inside the component |
+| `TypeError: useEffect is not a function` | React and react-dom versions mismatched | Pin matching versions in `add_dependencies` |
+| `TypeError: React.createElement is not a function` / `htm.bind is not a function` | Assigned the `await` result to `React`/`htm` directly — that value is the URL string | `await Fliplet.require.lazy('react'); const React = window.React;` (same for `htm`, `ReactDOM`, `ReactRouterDOM`) |
+| `Cannot read properties of undefined (reading 'Navigate'\|'Outlet'\|'useNavigate'\|…)` thrown from inside `react-router-dom.*.min.js` | `react-router-dom` UMD loaded without its peer UMDs — named exports are getters that forward to `window.ReactRouter` / `window.RemixRouter` | Also load `@remix-run/router` and `react-router` (matching minor version) before `react-router-dom`. See [Loading the framework](#loading-the-framework). |
+
+## DO / DON'T
+
+- DO use `htm` tagged templates as the default JSX alternative.
+- DO pass `basename: Fliplet.Router.getBasePath()` to `createBrowserRouter`.
+- DO resolve `Fliplet.Media.authenticate` inside `useEffect` and store in state.
+- DON'T ship raw JSX — it will always throw on first deploy.
+- DON'T use `HashRouter` — rejected by lint.
+- DON'T use `.tsx` or TypeScript — no transpiler available.
+- DON'T use CSS Modules or `import './styles.css'` — no bundler.
+- DON'T render with `innerHTML`, `outerHTML`, `insertAdjacentHTML`, or `element.append(htmlString)` inside screen files. If you wrote `el.innerHTML = ...` in a component, you wrote a templating engine — not React — and you introduced an XSS surface on every future edit.
+- DON'T write a manual `escapeHtml()` helper. Needing one means you're using `innerHTML` somewhere — fix that instead. React and `htm` escape interpolated values by default.
+- DON'T `if`-chain or `switch` on `location.pathname` to decide what to render, even with `react-router-dom` installed. That's what the router you just installed is for. (The boot-HTML lint flags this via `ruleId: path-dispatcher`.)
+- DON'T use raw `<a href="/path">` for in-app navigation — it triggers a full page reload and defeats the SPA. Use `<Link>` or `useNavigate()` from `react-router-dom`.
+- DON'T reach into screens from the boot file via `document.getElementById` / `querySelector`. Each screen owns its own state, fetches, and handlers; the boot owns routing and framework bootstrap only. If you're wiring screens from the outside, you've inverted the component model.
+
+## Related
+
+- [V3 app bootstrap](../app-bootstrap.md)
+- [V3 routing](../routing.md)
+- [V3 framework overview](overview.md)

--- a/docs/API/v3/frameworks/vanilla.md
+++ b/docs/API/v3/frameworks/vanilla.md
@@ -1,0 +1,64 @@
+---
+description: Constraints for building V3 apps in vanilla JavaScript. The simplest baseline — no framework deps to load, no transpile traps. Covers History API routing under Fliplet.Router.getBasePath and media asset binding timing.
+---
+
+# V3 vanilla-JS apps
+
+Vanilla JS is the lowest-friction V3 target because there is no framework to load and no syntax the browser can't parse. Most of the work is just respecting the V3 bootstrap contract and the routing lint.
+
+## Loading the framework
+
+Nothing to load. Still call `Fliplet().then(...)` before touching Fliplet APIs — the runtime needs to finish registering globals.
+
+## Features that need a build step
+
+Vanilla JS is the cheapest option precisely because nothing here needs a build step. Two things to still be careful of:
+
+- **No bare ESM imports across source files.** `import { helper } from './helpers'` fails because there is no bundler to resolve the specifier. Load shared code either as a single uploaded source file evaluated via `Fliplet.Media.getContents`, or as a registered dependency via `Fliplet.require.lazy`.
+- **Top-level `await` across files** won't work for the same reason — no module graph.
+
+Modern browser syntax (optional chaining, nullish coalescing, destructuring, async/await inside functions) is fine. The target is a current Chromium.
+
+## Wiring to Fliplet.Router
+
+Use the History API directly. The navigation call is:
+
+```js
+history.pushState({}, '', Fliplet.Router.getBasePath() + path);
+window.dispatchEvent(new PopStateEvent('popstate'));
+```
+
+Read the current route by stripping `Fliplet.Router.getBasePath()` from `location.pathname`. Route resolution (access check + screen-source fetch) goes through `Fliplet.Router.resolveRoute(path)` — see [V3 routing](../routing.md).
+
+## Binding Fliplet.Media.authenticate
+
+Authenticated URLs resolve asynchronously. Compute the URL, then assign it to the DOM element:
+
+```js
+const url = await Fliplet.Media.authenticate(rawUrl);
+imgEl.src = url;
+```
+
+Don't compute the URL at module load and hope it's ready — the element will have `src=""` (or the unauthenticated URL) for long enough to render broken.
+
+## Common errors
+
+| Symptom in `get_preview_logs('errors')` | Cause | Fix |
+|---|---|---|
+| `ReferenceError: Fliplet is not defined` | Code ran before `Fliplet().then(...)` resolved | Move initialization inside the `Fliplet().then(...)` callback |
+| `SyntaxError: Cannot use import statement outside a module` | ESM `import` in an uploaded source file | Load the dependency via `Fliplet.require.lazy` or inline the helper |
+| Image/font renders broken then disappears | Raw media URL used without `Fliplet.Media.authenticate` | Wrap the URL and assign after the promise resolves |
+
+## DO / DON'T
+
+- DO navigate with `history.pushState(state, '', Fliplet.Router.getBasePath() + path)`.
+- DO dispatch `popstate` after `pushState` so listeners re-render.
+- DON'T read or write `window.location.hash` — rejected by the routing lint.
+- DON'T use `href="#/..."` for internal links — rejected by the routing lint.
+- DON'T `import` across uploaded source files — resolve shared code via `Fliplet.require.lazy` or a single boot file.
+
+## Related
+
+- [V3 app bootstrap](../app-bootstrap.md)
+- [V3 routing](../routing.md)
+- [V3 framework overview](overview.md)

--- a/docs/API/v3/frameworks/vue.md
+++ b/docs/API/v3/frameworks/vue.md
@@ -1,0 +1,89 @@
+---
+description: Constraints for building V3 apps in Vue 3. Covers the runtime-compiler vs runtime-only build choice, the .vue single-file-component tradeoff without a loader, and the Vue Router base-path wiring to Fliplet.Router.getBasePath.
+---
+
+# V3 Vue apps
+
+Vue 3 is the best-supported multi-screen framework in V3 because a runtime-compiler build exists — meaning `template` strings compile in the browser without a toolchain. The traps below come from using the wrong Vue build, or reaching for features that assume Vite/webpack.
+
+## Loading the framework
+
+Add `vue` via `add_dependencies` with `lazy: true`, then:
+
+```js
+await Fliplet.require.lazy('vue');
+const Vue = window.Vue;
+```
+
+`Fliplet.require.lazy(name)` resolves once the UMD bundle has executed; the module itself lands on `window` (`window.Vue`, `window.VueRouter`). Read it off `window` after the `await` — assigning the awaited value directly gives you the URL string, not the module.
+
+**Pick the runtime-compiler build (usually `vue.global.js`), not the runtime-only build.** The runtime-only build (`vue.runtime.global.js`) does not include the template compiler — any component that uses `template: '...'` strings will fail to render. The runtime-only build only works if every component is authored as a pre-compiled render function, which is impractical without a bundler.
+
+For Vue Router, the separate dependency:
+
+```js
+await Fliplet.require.lazy('vue-router');
+const VueRouter = window.VueRouter;
+```
+
+## Features that need a build step
+
+| Feature | Why it fails | Do this instead |
+|---|---|---|
+| `.vue` single-file components | There is no loader resolving them at runtime | Use plain component objects with `template:` strings, **or** add `vue3-sfc-loader` as a dependency if the app genuinely needs SFCs. Pick one approach per app and stay consistent. |
+| `<script setup>` | Requires SFC compilation | Use the Options API or explicit `setup()` function on component objects. |
+| `<style scoped>` | Requires SFC compilation | Scope manually by wrapping each component's CSS in a root class selector. |
+| Bare ESM imports (`import Vue from 'vue'`) | No bundler resolves the specifier | Use `Fliplet.require.lazy('vue')`. |
+| TypeScript (`.ts`, `.tsx`) | No transpiler | Plain JavaScript. |
+
+## Wiring to Fliplet.Router
+
+Full contract is in [V3 routing](../routing.md). Vue-specific note: pass the base path into `createWebHistory`:
+
+```js
+const router = VueRouter.createRouter({
+  history: VueRouter.createWebHistory(Fliplet.Router.getBasePath()),
+  routes: [...]
+});
+```
+
+`createWebHashHistory` is rejected by the boot-HTML lint (rule `create-web-hash-history`).
+
+Build routes from `Fliplet.Router.getRouteManifest()` — do not hardcode. In each route's resolver, call `Fliplet.Router.resolveRoute(path)`. The `content` field in its result IS the screen's source — already fetched for you via `Fliplet.Media.getContents`. Return it from your loader and render it in your component; don't fetch the file again.
+
+## Binding Fliplet.Media.authenticate
+
+Authenticated URLs resolve asynchronously — bind through reactivity, not at module load:
+
+```js
+// inside a component
+data() { return { logoSrc: '' }; },
+async mounted() {
+  this.logoSrc = await Fliplet.Media.authenticate(rawUrl);
+}
+```
+
+Then `<img :src="logoSrc">`. Using `src="{{ rawUrl }}"` directly, or computing the authenticated URL at module scope, leaves the image broken until the template re-renders.
+
+## Common errors
+
+| Symptom in `get_preview_logs('errors')` | Cause | Fix |
+|---|---|---|
+| `[Vue warn]: Component is missing template or render function` | Runtime-only Vue build loaded; `template:` strings silently ignored | Switch to the runtime-compiler build (`vue.global.js`) |
+| `Uncaught SyntaxError: Unexpected token '<'` inside a component file | `.vue` SFC uploaded without `vue3-sfc-loader` | Either convert the component to a plain object with `template:` string, or add `vue3-sfc-loader` |
+| Blank screen, no errors | Component returned from `Fliplet.Media.getContents` wasn't registered before router resolved | Register the component inside the route resolver, not at module load |
+
+## DO / DON'T
+
+- DO use `Fliplet.require.lazy('vue')` and the runtime-compiler build.
+- DO build the router from `Fliplet.Router.getRouteManifest()` + `getBasePath()`.
+- DO bind authenticated media URLs into reactive `data()` fields.
+- DON'T use `createWebHashHistory` — rejected by lint.
+- DON'T author `.vue` SFCs without `vue3-sfc-loader` loaded.
+- DON'T `import` anything — use `Fliplet.require.lazy`.
+
+## Related
+
+- [V3 app bootstrap](../app-bootstrap.md)
+- [V3 routing](../routing.md)
+- [V3 framework overview](overview.md)

--- a/docs/API/v3/routing.md
+++ b/docs/API/v3/routing.md
@@ -1,0 +1,323 @@
+---
+description: Canonical routing patterns for V3 SPA apps. Covers base path, route manifest, access guard, per-framework examples, and the full list of forbidden patterns that break V3 apps.
+---
+
+# V3 routing
+
+This is the canonical routing reference for V3 apps. It covers the `Fliplet.Router` contract, the forbidden patterns that break V3 apps on one or more hosting contexts, per-framework examples (Vue Router 4, Vue Router 3, React Router, Svelte, vanilla JS), and the post-login redirect pattern.
+
+Routing in V3 is non-obvious because the defaults in most frameworks are wrong for the platform. V3 apps run in three different hosting contexts (slug-hosted web, Studio preview iframe, native shell), each with a different base path. Read this doc before writing boot HTML for any multi-screen V3 app.
+
+## Contents
+
+- [The contract](#the-contract)
+- [Forbidden patterns](#forbidden-patterns)
+- [Framework examples](#framework-examples)
+- [Post-login redirect](#post-login-redirect)
+- [Common pitfalls](#common-pitfalls)
+- [Related](#related)
+
+## The contract
+
+V3 uses the **History API on every platform** (web, preview iframe, and native). Hash routing is forbidden because every hosting context (slug-hosted web apps, the Studio preview iframe, and native shells) mounts the SPA at a different base path. Hashes hide that base from the server, break deep-link sharing, and make post-login redirects unreliable across the three contexts.
+
+<p class="info"><code>Fliplet.Router</code> is auto-loaded on V3 apps and is the only sanctioned router API. You build your framework's router from the manifest; you do not hand-roll routes.</p>
+
+```js
+var base     = Fliplet.Router.getBasePath();        // '/', '/my-slug/', '/v1/apps/42/pages/99/preview/', or native base
+var manifest = Fliplet.Router.getRouteManifest();   // { routes, defaultRoute, authRedirect }
+```
+
+Four requirements:
+
+1. **Read the base path** with `Fliplet.Router.getBasePath()` and pass it to your router's history/basename option. Never hardcode `'/'`. Slug-hosted apps, preview iframes, and native shells all have different bases.
+2. **Read the manifest** with `Fliplet.Router.getRouteManifest()`. Build your route table from `manifest.routes`. The manifest lives at `app.settings.v3` (see [App settings](app-settings.md)). Update it via the App Settings API (`PUT /v1/apps/:id` with `settings.v3`) or the Studio routing UI whenever you add or remove a user-visible route.
+3. **Guard each route with `Fliplet.Router.resolveRoute(path)`** in the component, loader, or resolver:
+   - It returns `{ allowed: true, content, route }` on success.
+   - It returns `{ allowed: false, redirectTo, reason }` on denial, where `reason` is `'no-session'` or `'media-denied'`.
+   - It already fetches the screen source via `Fliplet.Media.getContents(fileId)` internally. Don't call it yourself.
+   - It rejects on transient or infra errors (5xx, network) so you can show an error UI instead of redirecting silently.
+4. **Guard against stale navigations.** If the user has navigated away before an access check resolves, don't redirect. Compare the resolved route against the current route before calling `push`.
+
+<p class="warning"><strong>Server media ACL is the final gate.</strong> The manifest's <code>public: true</code> flag is advisory. It just lets the client skip a known-401 round trip. Flipping <code>public: true</code> in the manifest without updating the media file's access rule grants no access.</p>
+
+## Forbidden patterns
+
+These patterns break V3 apps on at least one hosting context (slug-hosted web, preview iframe, or native). Treat them as hard constraints. The Fliplet Studio AI builder enforces them with an automated lint on generated boot HTML (each violation carries a `ruleId` matching the rows below); hand-authored apps must follow the same rules.
+
+| `ruleId` | What's forbidden | What to do instead |
+|---|---|---|
+| `hash-change-event` | `window.addEventListener('hashchange', …)` or `window.onhashchange = …` | Use `popstate` with `history.pushState`. The browser fires `popstate` on back/forward; call `pushState` explicitly when navigating. |
+| `window-location-hash` | Reading or writing `window.location.hash` / `location.hash` | Navigate with `history.pushState(state, '', Fliplet.Router.getBasePath() + path)`. Read the current path from `location.pathname` after stripping the base prefix. |
+| `create-web-hash-history` | `VueRouter.createWebHashHistory(…)` | `VueRouter.createWebHistory(Fliplet.Router.getBasePath())`. |
+| `hash-router-react` | `HashRouter` (React Router) | `createBrowserRouter(routes, { basename: Fliplet.Router.getBasePath() })`. |
+| `hash-href` | `href="#/..."` or `href='#/...'` | Use real paths (`href="/home"`) and intercept clicks to call `history.pushState` via your router. |
+| `path-dispatcher` | 3+ `if (location.pathname === '/…')` branches, or `switch (location.pathname) { case '/…': … }`, used as a hand-rolled router | Build your framework's router from `Fliplet.Router.getRouteManifest()`. Each framework's wiring is in [Framework examples](#framework-examples) below. Single-branch guards like `if (location.pathname === '/login') return;` are fine — the lint only fires on dispatcher-shaped chains. |
+
+These six rules are the ones Fliplet can detect automatically from the boot HTML. Additional anti-patterns (hand-rolled `SCREENS` maps, pathname reads without base-stripping, double-fetching media) live in the [Common pitfalls](#common-pitfalls) section below. They aren't detected statically but are equally wrong.
+
+## Framework examples
+
+The same pattern applies to every framework: read the base path and manifest from `Fliplet.Router`, build the framework's router from that, and call `resolveRoute` in the component, loader, or resolver. The examples below show the shape in five common stacks; pick whichever matches your app.
+
+Every example assumes this manifest shape (see [App settings](app-settings.md) for how it's stored):
+
+```json
+{
+  "routes": [
+    { "name": "Home",      "path": "/home",       "fileId": 222, "public": true },
+    { "name": "Login",     "path": "/login",      "fileId": 444, "public": true },
+    { "name": "MyAccount", "path": "/my-account", "fileId": 333 }
+  ],
+  "defaultRoute": "/home",
+  "authRedirect": "/login"
+}
+```
+
+### Vue Router 4 (Vue 3)
+
+```js
+Fliplet.require.lazy('vue-router').then(function() {
+  var manifest = Fliplet.Router.getRouteManifest();
+  var history = VueRouter.createWebHistory(Fliplet.Router.getBasePath());
+
+  var routes = manifest.routes.map(function(r) {
+    return {
+      path: r.path,
+      name: r.name,
+      component: function() {
+        return Fliplet.Router.resolveRoute(r.path).then(function(result) {
+          if (!result.allowed) {
+            // Race guard: only redirect if the user is still on this route.
+            if (router.currentRoute.value.path === r.path) {
+              router.push(result.redirectTo);
+            }
+
+            return { template: '<div></div>' };
+          }
+
+          return parseScreen(result.content); // framework-specific
+        });
+      }
+    };
+  });
+
+  routes.unshift({ path: '/', redirect: manifest.defaultRoute });
+
+  var router = VueRouter.createRouter({ history: history, routes: routes });
+  // mount and use the router as usual
+});
+```
+
+### Vue Router 3 (Vue 2)
+
+```js
+Fliplet.require.lazy('vue-router').then(function() {
+  var manifest = Fliplet.Router.getRouteManifest();
+
+  var routes = manifest.routes.map(function(r) {
+    return {
+      path: r.path,
+      name: r.name,
+      component: function(resolve) {
+        Fliplet.Router.resolveRoute(r.path).then(function(result) {
+          if (!result.allowed) {
+            if (router.currentRoute.path === r.path) {
+              router.push(result.redirectTo);
+            }
+
+            resolve({ template: '<div></div>' });
+
+            return;
+          }
+
+          resolve(parseScreen(result.content));
+        });
+      }
+    };
+  });
+
+  routes.unshift({ path: '/', redirect: manifest.defaultRoute });
+
+  var router = new VueRouter({
+    mode: 'history',
+    base: Fliplet.Router.getBasePath(),
+    routes: routes
+  });
+});
+```
+
+### React Router 6
+
+React Router doesn't infer the base path; you must pass it to `basename`. Use a loader to call `resolveRoute` before the component renders.
+
+```js
+Fliplet.require.lazy('react-router-dom').then(function() {
+  var manifest = Fliplet.Router.getRouteManifest();
+
+  function routeLoader(path) {
+    return function() {
+      return Fliplet.Router.resolveRoute(path).then(function(result) {
+        if (!result.allowed) {
+          throw ReactRouterDOM.redirect(result.redirectTo);
+        }
+
+        return { content: result.content, route: result.route };
+      });
+    };
+  }
+
+  var routes = manifest.routes.map(function(r) {
+    return {
+      path: r.path,
+      loader: routeLoader(r.path),
+      element: React.createElement(ScreenRenderer)
+    };
+  });
+
+  routes.unshift({ path: '/', loader: function() { throw ReactRouterDOM.redirect(manifest.defaultRoute); } });
+
+  var router = ReactRouterDOM.createBrowserRouter(routes, {
+    basename: Fliplet.Router.getBasePath()
+  });
+});
+```
+
+`ScreenRenderer` reads `useLoaderData()` and renders `data.content`. Race-handling is built in; React Router cancels stale loaders automatically.
+
+### Svelte
+
+Most Svelte routers default to hash mode. Pick one that supports history, or thin-wrap `history.pushState` yourself:
+
+```js
+var manifest = Fliplet.Router.getRouteManifest();
+var base = Fliplet.Router.getBasePath();
+
+function navigate(path) {
+  history.pushState({}, '', base.replace(/\/$/, '') + path);
+  render(path);
+}
+
+function render(path) {
+  var target = path === '/' ? manifest.defaultRoute : path;
+
+  Fliplet.Router.resolveRoute(target).then(function(result) {
+    if (location.pathname !== base.replace(/\/$/, '') + target) return; // stale
+
+    if (!result.allowed) {
+      navigate(result.redirectTo);
+
+      return;
+    }
+
+    mountScreen(result.content);
+  });
+}
+
+window.addEventListener('popstate', function() {
+  render(location.pathname.replace(new RegExp('^' + base.replace(/\/$/, '')), '') || '/');
+});
+
+render(location.pathname.replace(new RegExp('^' + base.replace(/\/$/, '')), '') || '/');
+```
+
+### Vanilla JS (no router library)
+
+Same pattern as Svelte: `pushState` for navigation, `popstate` for back/forward, normalize against the base path. Keep a module-scoped `currentNavId` to ignore stale resolutions:
+
+```js
+var manifest = Fliplet.Router.getRouteManifest();
+var base = Fliplet.Router.getBasePath();
+var basePrefix = base.replace(/\/$/, '');
+var currentNavId = 0;
+
+function stripBase(pathname) {
+  if (basePrefix && pathname.indexOf(basePrefix) === 0) {
+    return pathname.slice(basePrefix.length) || '/';
+  }
+  return pathname || '/';
+}
+
+function render(path) {
+  var navId = ++currentNavId;
+  var target = (path && path !== '/') ? path : manifest.defaultRoute;
+
+  return Fliplet.Router.resolveRoute(target).then(function(result) {
+    if (navId !== currentNavId) return; // user navigated away, ignore
+
+    if (!result.allowed) {
+      navigate(result.redirectTo);
+      return;
+    }
+
+    document.getElementById('app').innerHTML = result.content;
+  });
+}
+
+function navigate(path) {
+  history.pushState({}, '', basePrefix + path);
+  render(path);
+}
+
+document.addEventListener('click', function(event) {
+  var link = event.target.closest('a[href^="/"]');
+  if (!link || link.target === '_blank' || event.metaKey || event.ctrlKey) return;
+  event.preventDefault();
+  navigate(link.getAttribute('href'));
+});
+
+window.addEventListener('popstate', function() {
+  render(stripBase(location.pathname));
+});
+
+render(stripBase(location.pathname));
+```
+
+## Post-login redirect
+
+When `resolveRoute` returns `reason: 'no-session'` or `reason: 'media-denied'`, stash the intended path before navigating to `authRedirect`. After a successful login, consume it.
+
+### Vue Router 4 example
+
+```js
+// Before redirecting to the auth screen:
+sessionStorage.setItem('fl:postLoginPath', router.currentRoute.value.fullPath);
+router.push(result.redirectTo);
+
+// After a successful login:
+var target = sessionStorage.getItem('fl:postLoginPath');
+sessionStorage.removeItem('fl:postLoginPath');
+router.push(target || manifest.defaultRoute);
+```
+
+### Framework-agnostic equivalent
+
+```js
+// Before redirecting to the auth screen:
+sessionStorage.setItem('fl:postLoginPath', location.pathname + location.search);
+navigate(result.redirectTo);
+
+// After a successful login:
+var target = sessionStorage.getItem('fl:postLoginPath');
+sessionStorage.removeItem('fl:postLoginPath');
+navigate(target || manifest.defaultRoute);
+```
+
+Replace `navigate(...)` with the same helper used in your router (Svelte, vanilla JS, or React Router's `navigate()` from `useNavigate()`).
+
+## Common pitfalls
+
+- **Don't hand-roll a `SCREENS = { home: 1234, … }` map or a pathname-if-chain.** That's what the route manifest is for. Store it in `app.settings.v3` and read it back via `Fliplet.Router.getRouteManifest().routes`. Hand-rolled maps drift when screens are renamed, duplicate the `public` and `fileId` metadata the server already authored, and bypass the manifest as the single source of truth for routing.
+- **Don't read `window.location.pathname` directly to determine the current route.** Strip the base path first. `Fliplet.Router.getBasePath()` returns the prefix to remove. Slug-hosted apps and preview iframes host the SPA under a non-root path; raw `pathname` reads will misidentify the current route in both contexts.
+- **Don't fetch the screen's media URL yourself.** `Fliplet.Router.resolveRoute` already calls `Fliplet.Media.getContents(fileId)` under the hood and returns the content in `result.content`. A second fetch duplicates the network round trip, can race with the access check, and will fail outright on private media where auth headers aren't applied.
+- **Don't discard `result.content` from `resolveRoute`.** The `content` field IS the screen's source — already fetched for you. Your route loader should return `{ content: result.content, route: result.route }` so the component can render `data.content` directly. If your loader returns only `{ path }` and your screens are defined inline in the component, you've duplicated every screen in two places — the manifest's `fileId` and the hardcoded inline copy — and you've paid for a fetch you then threw away. The `resolveRoute` name is the hint: the method resolves a route to its **full resolution** (access + content), not just an access decision.
+- **Don't assume the server-side ACL matches the manifest's `public` flag.** The manifest is advisory; the server decides. Always handle `reason: 'media-denied'`. Flipping `public: true` without updating the media file's access rule grants no access; you'll ship an app that works in dev and 401s in production.
+- **Don't skip the route manifest on multi-screen apps.** The manifest at `app.settings.v3` IS the app's routing definition. Without it, `Fliplet.Router.getRouteManifest().routes` is empty and nothing resolves. The boot HTML has no fallback path list; an empty manifest silently renders a blank app.
+- **Don't use raw `<a href="/path">` for in-app navigation.** It triggers a full page reload and tears down your SPA — the framework re-bootstraps from scratch on every click, state is lost, and the post-login redirect pattern breaks because your app never saw the original navigation. Intercept clicks via your framework's router: Vue Router's `<router-link>`, React Router's `<Link>` (or `useNavigate()`), or a vanilla click handler that calls `history.pushState`. External links (`http(s)://…`, `mailto:`, `tel:`) are fine as raw `<a>` — those are *supposed* to leave the SPA.
+
+## Related
+
+- [Fliplet Router JS API](fliplet-router.md). Full method reference for `Fliplet.Router` with return shapes, reason codes, and manifest shape.
+- [V3 app bootstrap constraints](app-bootstrap.md). The three boot-HTML fundamentals (dependencies, media fetch, init sequence). Routing defers to this doc.
+- [V3 app settings convention](app-settings.md). Where the route manifest is stored (`app.settings.v3`).
+- [Media JS APIs](../fliplet-media.md). `Fliplet.Media.getContents` details.


### PR DESCRIPTION
Eleven V3-reference markdown files lived only on `origin/development` and the v3/DEV-908-beta* feature branches; `origin/master` had none of them.

The Studio AI builder's `fetch_fliplet_doc` tool fetches via `https://raw.githubusercontent.com/Fliplet/fliplet-cli/<branch>/docs/<path>` with a fallback chain of STUDIO_BRANCH → development (in non-prod) → master (in prod). In production builds — where there's no STUDIO_BRANCH set — every `API/v3/*` fetch was 404'ing, including paths the AI tools and builder.md actively reference (V3 routing, V3 app-bootstrap, V3 frameworks, etc.). The skill recipes have most content inlined so this didn't always block builds, but `updateScreenCode.js`'s lint-error guidance points at `API/v3/routing.md` / `API/v3/app-bootstrap.md` — those fetches were silently failing in prod.

This branch brings the V3 docs from `origin/development` onto a focused branch off master so they can be merged via PR. Files are taken verbatim from `origin/development` at the time of this commit:

- API/v3/auth.md
- API/v3/app-settings.md
- API/v3/app-bootstrap.md
- API/v3/routing.md
- API/v3/fliplet-router.md
- API/v3/analytics.md
- API/v3/frameworks/overview.md
- API/v3/frameworks/{vanilla,vue,react,alpine}.md

Total 1822 lines, 11 files. Pure additive vs master — no existing files modified.