### PR TITLE
docs: exclude mcp-worker/ from Jekyll (drops the last sitemap 404)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -39,3 +39,8 @@ exclude:
   - node_modules
   - CLAUDE.md
   - .well-known
+  # mcp-worker/ is the Cloudflare Worker source. Its README is dev
+  # documentation for the Worker, not a public doc — excluding it
+  # stops Jekyll indexing it (and stops jekyll-sitemap listing
+  # /mcp-worker/README which 404s on the live site).
+  - mcp-worker


### PR DESCRIPTION
Tiny follow-up to #263. The post-deploy audit found one residual error: `/mcp-worker/README` is in the sitemap but 404s.

`mcp-worker/README.md` is the Cloudflare Worker's own README (dev docs for the worker source, not a public page). Jekyll was indexing it and `jekyll-sitemap` was listing it, but the path doesn't actually serve — the worker handles `/mcp`, not `/mcp-worker/`.

Add `mcp-worker` to the Jekyll `exclude:` list. After this:

- Sitemap will not include `/mcp-worker/README`
- Page won't be built into `_site/`
- Last error in the audit drops to **zero**

Built locally and verified: 0 mcp-worker entries in sitemap, no `_site/mcp-worker/` directory.