### PR TITLE
docs(v3): mark fliplet-chat as owning its conversations/messages DSes

### DIFF
--- a/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
@@ -54,7 +54,7 @@ The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User
 - [Fliplet.Media.Audio.Player](https://developers.fliplet.com/API/fliplet-audio-player.html): Embed an audio player UI in a screen by tagging HTML elements with audio URLs; the framework auto-initializes players on screen load.
 - [Fliplet.Media.Audio](https://developers.fliplet.com/API/fliplet-audio.html): Play, pause, stop, and seek audio files on device or from a URL in Fliplet apps via the Audio namespace.
 - [Fliplet.Barcode](https://developers.fliplet.com/API/fliplet-barcode.html): Generate QR codes and 1D/2D barcodes on screen, and scan them from the device camera, via the fliplet-barcode package.
-- [Fliplet.Chat](https://developers.fliplet.com/API/fliplet-chat.html): Build chat, group conversations, and public channels in a Fliplet app via the fliplet-chat package, which exposes Fliplet.Chat, Fliplet.Chat.connect, and Fliplet.Chat.init.
+- [Fliplet.Chat](https://developers.fliplet.com/API/fliplet-chat.html): Build one-to-one, group, and public-channel chat features. Fliplet.Chat owns the conversations and messages data sources internally — supply only the contacts list (who can chat with whom).
 - [Fliplet.Communicate](https://developers.fliplet.com/API/fliplet-communicate.html): Send email, SMS, push notifications, and share URLs from a Fliplet app using a single Communicate namespace.
 - [Fliplet.Content()](https://developers.fliplet.com/API/fliplet-content.html): Create, query, update, and delete shared content records (bookmarks, likes, saved searches) backed by a data source via Fliplet.Content.
 - [Fliplet.CSV](https://developers.fliplet.com/API/fliplet-csv.html): Encode and decode CSV in Fliplet apps via the fliplet-csv package.

--- a/docs/.well-known/agent-skills/index.json
+++ b/docs/.well-known/agent-skills/index.json
@@ -130,7 +130,7 @@
       "tags": [
         "js-api"
       ],
-      "sha256": "901cd7e4a7b8b56ca226b0a9f7d2760ce7d73eeef166c36e067846bc78ec3b8b"
+      "sha256": "1e5a933f3b7a286d7a1cc84417319e10eece8e986cecb8389c943e3b45a83658"
     },
     {
       "name": "fliplet-docs-index",

--- a/docs/.well-known/llms-v3-libraries.json
+++ b/docs/.well-known/llms-v3-libraries.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-15T23:42:02.520Z",
+  "generatedAt": "2026-05-16T15:54:05.264Z",
   "libraries": [
     {
       "package": "fliplet-app-submissions",
@@ -65,7 +65,7 @@
       "package": "fliplet-chat",
       "namespace": "Fliplet.Chat",
       "title": "Fliplet.Chat",
-      "description": "Build chat, group conversations, and public channels in a Fliplet app via the fliplet-chat package, which exposes Fliplet.Chat, Fliplet.Chat.connect, and Fliplet.Chat.init.",
+      "description": "Build one-to-one, group, and public-channel chat features. Fliplet.Chat owns the conversations and messages data sources internally — supply only the contacts list (who can chat with whom).",
       "docUrl": "https://developers.fliplet.com/API/fliplet-chat.html",
       "preloaded": false,
       "capabilities": [
@@ -79,8 +79,11 @@
         "messaging",
         "real-time chat",
         "contacts",
-        "chat room"
-      ]
+        "chat room",
+        "typing indicator",
+        "message history"
+      ],
+      "notes": "Owns the conversations and messages data sources internally — never propose `Conversations`, `Messages`, `Typing Status`, or similar data sources of your own. The only data source you design is the `contacts` list passed to `Fliplet.Chat.connect()` (who can chat with whom)."
     },
     {
       "package": "fliplet-communicate",

--- a/docs/.well-known/llms.txt
+++ b/docs/.well-known/llms.txt
@@ -102,7 +102,7 @@
 - [Fliplet.Media.Audio.Player](https://developers.fliplet.com/API/fliplet-audio-player.html): Embed an audio player UI in a screen by tagging HTML elements with audio URLs; the framework auto-initializes players on screen load.
 - [Fliplet.Media.Audio](https://developers.fliplet.com/API/fliplet-audio.html): Play, pause, stop, and seek audio files on device or from a URL in Fliplet apps via the Audio namespace.
 - [Fliplet.Barcode](https://developers.fliplet.com/API/fliplet-barcode.html): Generate QR codes and 1D/2D barcodes on screen, and scan them from the device camera, via the fliplet-barcode package.
-- [Fliplet.Chat](https://developers.fliplet.com/API/fliplet-chat.html): Build chat, group conversations, and public channels in a Fliplet app via the fliplet-chat package, which exposes Fliplet.Chat, Fliplet.Chat.connect, and Fliplet.Chat.init.
+- [Fliplet.Chat](https://developers.fliplet.com/API/fliplet-chat.html): Build one-to-one, group, and public-channel chat features. Fliplet.Chat owns the conversations and messages data sources internally — supply only the contacts list (who can chat with whom).
 - [Fliplet.Communicate](https://developers.fliplet.com/API/fliplet-communicate.html): Send email, SMS, push notifications, and share URLs from a Fliplet app using a single Communicate namespace.
 - [Fliplet.Content()](https://developers.fliplet.com/API/fliplet-content.html): Create, query, update, and delete shared content records (bookmarks, likes, saved searches) backed by a data source via Fliplet.Content.
 - [Fliplet.CSV](https://developers.fliplet.com/API/fliplet-csv.html): Encode and decode CSV in Fliplet apps via the fliplet-csv package.

--- a/docs/API/fliplet-chat.md
+++ b/docs/API/fliplet-chat.md
@@ -1,11 +1,12 @@
 ---
 title: Fliplet.Chat
-description: Build chat, group conversations, and public channels in a Fliplet app via the fliplet-chat package, which exposes Fliplet.Chat, Fliplet.Chat.connect, and Fliplet.Chat.init.
+description: Build one-to-one, group, and public-channel chat features. Fliplet.Chat owns the conversations and messages data sources internally — supply only the contacts list (who can chat with whom).
 type: api-reference
 tags: [js-api, chat, messaging, realtime, conversations]
 v3_relevant: true
 deprecated: false
-capabilities: [chat, conversation, group chat, public channel, direct message, dm, im, messaging, real-time chat, contacts, chat room]
+capabilities: [chat, conversation, group chat, public channel, direct message, dm, im, messaging, real-time chat, contacts, chat room, typing indicator, message history]
+notes: "Owns the conversations and messages data sources internally — never propose `Conversations`, `Messages`, `Typing Status`, or similar data sources of your own. The only data source you design is the `contacts` list passed to `Fliplet.Chat.connect()` (who can chat with whom)."
 ---
 # `Fliplet.Chat`
 


### PR DESCRIPTION
## Summary

E2E verification of the V3 builder's "Fliplet API anchoring" change (PR #265) revealed that the **chat** capability still bypasses `fliplet-chat`. The agent saw the registry entry but proposed `Conversations`, `Messages`, and `Typing Status` data sources from scratch.

The previous doc description called the package *"a thin wrapper over the Fliplet Data Sources APIs"* — language that invites the planner to help by designing those data sources itself.

This PR:

- Rewrites the description as **ownership-explicit**: "Fliplet.Chat owns the conversations and messages data sources internally — supply only the contacts list (who can chat with whom)."
- Adds a `notes` field that binds the planner: never propose `Conversations`, `Messages`, `Typing Status`, etc. — only the `contacts` list passed to `connect()`.
- Adds two capability keywords surfaced in the failing case: `typing indicator` and `message history`.

Studio's V3 builder consumes this via the bundled snapshot of `/.well-known/llms-v3-libraries.json`. After this PR merges + Cloudflare Pages republishes, Studio's `npm run fetch-fliplet-apis` will pick up the new wording.

## Test plan

- [x] `node --test bin/__tests__/build-agent-indexes.test.mjs` — 76 pass (unchanged from PR #265)
- [x] `node bin/build-agent-indexes.mjs` — regenerates `.well-known/llms-v3-libraries.json` with the new entry, confirmed via `jq '.libraries[] | select(.package == \"fliplet-chat\")'`
- [ ] Reviewer: confirm the H1/body of `API/fliplet-chat.md` still reads cleanly with the updated frontmatter (the body wasn't touched in this PR).
- [ ] Post-merge: re-run the V2b chat e2e verification in fliplet-studio — pass criterion is that the agent references \`fliplet-chat\` in its plan and does NOT propose Conversations/Messages/Typing Status data sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)