### PR TITLE
docs(navigator): add geolocation/GPS capabilities so V3 AI anchors location requests

### DIFF
--- a/docs/API/core/navigator.md
+++ b/docs/API/core/navigator.md
@@ -1,15 +1,15 @@
 ---
 title: Fliplet.Navigator
-description: "Detect online/offline state, listen for connectivity changes, and wait for the device to be ready."
+description: "Detect online/offline state, listen for connectivity changes, wait for the device to be ready, and get the device's current GPS location and coordinates."
 type: api-reference
 tags: [js-api, core, navigator]
 v3_relevant: true
 deprecated: false
-capabilities: [online, offline, connectivity, network state, device ready, network change, online status, offline detection]
+capabilities: [online, offline, connectivity, network state, device ready, network change, online status, offline detection, location, gps, geolocation, current location, device location, coordinates, latitude, longitude, position, nearby, geofence, map location]
 ---
 # `Fliplet.Navigator`
 
-Detect online/offline state, listen for connectivity changes, and wait for the device to be ready.
+Detect online/offline state, listen for connectivity changes, wait for the device to be ready, and get the device's current GPS location and coordinates.
 
 ### Check whether the device is online
 


### PR DESCRIPTION
# PR A: Add geolocation/GPS capabilities to `Fliplet.Navigator` docs

**Repo:** `Fliplet/fliplet-cli`
**Base branch:** `master` (docs repo — the no-master rule applies only to fliplet-api / fliplet-studio)
**Suggested branch:** `docs/navigator-geolocation-capabilities`
**File:** `docs/API/core/navigator.md`
**Diff:** `PR-A_fliplet-cli_navigator.diff` (git-applyable)

## Why

Live test on `development` (2026‑05‑30): when the V3 builder is asked for the user's location/GPS, **no Fliplet API is surfaced** — neither the API registry nor the live docs search points to `Fliplet.Navigator.location()`, even though that method exists and is documented in this very file. The AI therefore falls back to the browser HTML5 Geolocation API, which does not use Fliplet's native bridge.

Root cause: the V3 AI's API registry (`fliplet-studio/src/v3/ai/data/fliplet-apis.json`) and the docs search index (`developers.fliplet.com/.well-known/llms.txt`) are **generated from this doc's frontmatter** by `docs/bin/build-agent-indexes.mjs`. The frontmatter `capabilities:` lists only online/offline/connectivity — it omits location/GPS entirely, and the `description:` doesn't mention location. So the capability keyword match the AI relies on never fires.

## What changed

`docs/API/core/navigator.md` frontmatter (+ the intro line, kept in sync):
- `capabilities:` — added `location, gps, geolocation, current location, device location, coordinates, latitude, longitude, position, nearby, geofence, map location`.
- `description:` — extended to "…and get the device's current GPS location and coordinates."

No code, no API behaviour change — documentation metadata only.

## ⚠️ Required follow-up after merge (not automatic)

The registry/index artifacts are build-time snapshots. After this merges:
1. Re-run `docs/bin/build-agent-indexes.mjs` and republish `llms.txt` (docs-site build).
2. Regenerate and commit the updated `src/v3/ai/data/fliplet-apis.json` snapshot in **fliplet-studio** (whatever step normally produces it). Confirm with the V3 team whether this is a CI step or manual.

## Verification (done)

Replicated the builder's exact production ranking (`scoreEntry`/`rankAndSlice` from `searchFlipletDocs.js`) against the live `llms.txt`, before vs after:

| Query | Before | After |
|---|---|---|
| "show my current location" | NONE | **Fliplet.Navigator** (rank 1) |
| "get the user gps location" | Fliplet.User / SDK intro | **Fliplet.Navigator** now surfaces |

Registry: after regen, `Fliplet.Navigator` will carry `location, gps, geolocation` capabilities, so the **binding** "Fliplet API anchoring" rule resolves location requests to `Fliplet.Navigator.location()`. YAML frontmatter validated (20 capability keywords parse cleanly).

## Test plan (reviewer)

After regen, in V3 prompt "show the user's current location on the screen" → confirm the AI anchors to `Fliplet.Navigator.location()` and does **not** emit `navigator.geolocation`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)