### PR TITLE
DEV-1306: docs — make V3 routing platform-conditional (history on web, hash on native)

### DIFF
--- a/docs/API/v3/app-bootstrap.md
+++ b/docs/API/v3/app-bootstrap.md
@@ -50,7 +50,7 @@ Fliplet().then(function() {
 
 ## What's next: routing
 
-V3 uses History API routing driven by the manifest at `app.settings.v3`, accessed via `Fliplet.Router`. Hash routing is forbidden on every platform. For the full contract, per-framework examples, and the anti-patterns that break V3 apps, see [V3 routing](routing.md).
+V3 routing is driven by the manifest at `app.settings.v3`, accessed via `Fliplet.Router`. It's platform-conditional: History API on web, hash on native (Cordova `file://` blocks `pushState` path changes) — branch on `Fliplet.Router.isNative()`. For the full contract, per-framework examples, and the anti-patterns that break V3 apps, see [V3 routing](routing.md).
 
 ## Related
 

--- a/docs/API/v3/auth.md
+++ b/docs/API/v3/auth.md
@@ -234,7 +234,7 @@ async function getCurrentUser() {
 
 ## Logout
 
-Clear the session and redirect to the login screen. V3 uses History API routing on every platform, so redirect via your router (or `history.pushState` + `Fliplet.Router.getBasePath()`) — never `window.location.hash`. See [V3 Routing](routing.md) for the full contract.
+Clear the session and redirect to the login screen. Redirect via your router so the platform-correct history backend is used (History API on web, hash on native). If you redirect by hand instead of through a router, branch on `Fliplet.Router.isNative()` — `history.pushState` + `Fliplet.Router.getBasePath()` on web, `location.hash` on native. See [V3 Routing](routing.md) for the full contract.
 
 ```js
 // Called from a component that has a router instance in scope.

--- a/docs/API/v3/fliplet-router.md
+++ b/docs/API/v3/fliplet-router.md
@@ -1,5 +1,5 @@
 ---
-description: Fliplet.Router JS API reference for V3 apps. Covers getBasePath, getRouteManifest, getRouteConfig, and resolveRoute including return shapes, reason codes, and rejection behavior.
+description: Fliplet.Router JS API reference for V3 apps. Covers getBasePath, isNative, getHistoryMode (platform-conditional history — path on web, hash on native), getRouteManifest, getRouteConfig, and resolveRoute including return shapes, reason codes, and rejection behavior.
 ---
 
 # Fliplet Router JS API
@@ -14,6 +14,8 @@ For the full routing contract, per-framework integration examples, and forbidden
 
 - [Methods](#methods)
   - [getBasePath()](#flipletroutergetbasepath)
+  - [isNative()](#flipletrouterisnative)
+  - [getHistoryMode()](#flipletroutergethistorymode)
   - [getRouteManifest()](#flipletroutergetroutemanifest)
   - [getRouteConfig(path)](#flipletroutergetrouteconfigpath)
   - [resolveRoute(pathOrRoute)](#flipletrouterresolveroutepathorroute)
@@ -38,17 +40,45 @@ The value depends on the hosting context:
 | Studio preview iframe | `/v1/apps/42/pages/99/preview/` |
 | Native shell | Computed by the shell at runtime |
 
+The base path applies to **web** history only. On native the app routes through the hash, which takes no base — branch on [`Fliplet.Router.isNative()`](#flipletrouterisnative):
+
 ```js
 var base = Fliplet.Router.getBasePath();
 
-// Pass to Vue Router 4:
-var history = VueRouter.createWebHistory(base);
+// Vue Router 4 — platform-conditional history backend:
+var history = Fliplet.Router.isNative()
+  ? VueRouter.createWebHashHistory()        // native — hash, no base
+  : VueRouter.createWebHistory(base);       // web — path + base
 
-// Pass to React Router 6:
-var router = ReactRouterDOM.createBrowserRouter(routes, { basename: base });
+// React Router 6 — createHashRouter on every platform (no basename):
+var router = ReactRouterDOM.createHashRouter(routes);
 ```
 
-<p class="warning">Never hardcode <code>'/'</code>. Slug-hosted apps, preview iframes, and native shells all mount the SPA at a different base.</p>
+<p class="warning">On web, never hardcode <code>'/'</code> — slug-hosted apps and preview iframes mount the SPA at a different base. Don't pass the base path to the native (hash) history backend.</p>
+
+### `Fliplet.Router.isNative()`
+
+Returns whether the app is running inside a native (Cordova) shell, where pages are served from a `file://` URL. This is the single source of truth for the routing platform branch: native shells block `history.pushState()` from changing the path of a `file:` URL, so they must route through the hash.
+
+**Returns:** `Boolean` — `true` in a native shell, `false` on web (slug-hosted apps and the Studio preview iframe).
+
+```js
+var history = Fliplet.Router.isNative()
+  ? VueRouter.createWebHashHistory()                       // native — hash only
+  : VueRouter.createWebHistory(Fliplet.Router.getBasePath()); // web — path + base
+```
+
+### `Fliplet.Router.getHistoryMode()`
+
+Returns the history mode the app should use, derived from [`isNative()`](#flipletrouterisnative). Use it when you want the decision as a value rather than a boolean branch.
+
+**Returns:** `String` — `'hash'` on native, `'history'` on web.
+
+```js
+if (Fliplet.Router.getHistoryMode() === 'hash') {
+  // route via location.hash
+}
+```
 
 ### `Fliplet.Router.getRouteManifest()`
 

--- a/docs/API/v3/frameworks/alpine.md
+++ b/docs/API/v3/frameworks/alpine.md
@@ -1,5 +1,5 @@
 ---
-description: Constraints for building V3 apps in Alpine.js. Alpine is attribute-driven HTML with no build step, so it maps cleanly to the V3 runtime. Covers x-init timing relative to Fliplet().then and History API routing pairing.
+description: Constraints for building V3 apps in Alpine.js. Alpine is attribute-driven HTML with no build step, so it maps cleanly to the V3 runtime. Covers x-init timing relative to Fliplet().then and platform-conditional routing pairing (History API on web, location.hash on native, branched on Fliplet.Router.isNative).
 ---
 
 # V3 Alpine.js apps
@@ -27,16 +27,20 @@ None that Alpine itself requires. The generic V3 constraints still apply:
 
 ## Wiring to Fliplet.Router
 
-Alpine has no router. Pair it with History API routing the same way as vanilla JS:
+Alpine has no router. Pair it with platform-conditional routing the same way as vanilla JS — History API on web, hash on native (Cordova `file://` blocks `pushState` path changes):
 
 ```js
 function goTo(path) {
-  history.pushState({}, '', Fliplet.Router.getBasePath() + path);
-  window.dispatchEvent(new PopStateEvent('popstate'));
+  if (Fliplet.Router.isNative()) {
+    location.hash = path;                                        // native — fires 'hashchange'
+  } else {
+    history.pushState({}, '', Fliplet.Router.getBasePath() + path);
+    window.dispatchEvent(new PopStateEvent('popstate'));         // web — fires 'popstate'
+  }
 }
 ```
 
-Use `Fliplet.Router.resolveRoute(path)` in your `popstate` handler. See [V3 routing](../routing.md).
+Use `Fliplet.Router.resolveRoute(path)` in your route handler, and listen for `hashchange` on native / `popstate` on web. See [V3 routing](../routing.md).
 
 ## Binding Fliplet.Media.authenticate
 
@@ -64,7 +68,7 @@ The `:src="src"` binding updates once the promise resolves. Do not try `:src="Fl
 - DO resolve authenticated URLs into a reactive `x-data` field before binding.
 - DO pair Alpine with History API routing from `Fliplet.Router.getBasePath()`.
 - DON'T bind a Promise directly into an attribute (`:src`, `:href`).
-- DON'T use hash-based navigation — rejected by lint.
+- DON'T use hash-based navigation on web — the lint flags it unless you branch on `Fliplet.Router.isNative()` (hash is the required native branch).
 
 ## Related
 

--- a/docs/API/v3/frameworks/overview.md
+++ b/docs/API/v3/frameworks/overview.md
@@ -15,17 +15,17 @@ Fetch the per-framework doc (`v3-framework-vue`, `v3-framework-react`, etc.) bef
 | No transpile | JSX, TSX, and any other syntax the browser can't parse natively will throw `SyntaxError: Unexpected token`. |
 | No bundler | Bare ESM imports (`import x from 'vue'`) fail. Dependencies must come from `Fliplet.require.lazy(name)` or a full CDN URL added via `add_dependencies`. |
 | No CSS preprocessing | No CSS Modules, no Sass, no PostCSS. Styles are plain CSS inlined in `<style>` or component HTML. |
-| Hash routing is rejected | `hashchange`, `window.location.hash`, `createWebHashHistory`, `HashRouter`, and `href="#/..."` are all rejected by the boot-HTML lint. History API only. See [V3 routing](../routing.md). |
+| Routing is platform-conditional | History API on web, hash on native (Cordova `file://` blocks `pushState` path changes). Branch the history backend on `Fliplet.Router.isNative()`. The boot-HTML lint flags unguarded hash patterns (`createWebHashHistory`, `location.hash`, `hashchange`, `href="#/..."`) AND unguarded `createWebHistory`. React is the exception — `createHashRouter` on every platform, no branch. See [V3 routing](../routing.md). |
 | Preloaded libraries | jQuery, Bootstrap CSS, Lodash, Moment, Animate.css, and fliplet-media are always available — never add them as dependencies. |
 
 ## Framework comparison
 
 | Framework | Needs compile? | Router support | Good fit for |
 |---|---|---|---|
-| Vanilla JS | No | History API (manual) | Single-screen apps, very simple flows |
-| Vue 3 | No (runtime-compiler build) | Vue Router 4 (`createWebHistory`) | Multi-screen apps with reactive state |
-| React | **Yes, for JSX** | React Router 6 (`basename`) | Users who asked for React; otherwise prefer Vue |
-| Alpine.js | No | Pair with vanilla History API | Form-heavy, attribute-driven UIs |
+| Vanilla JS | No | History API on web, hash on native (manual branch) | Single-screen apps, very simple flows |
+| Vue 3 | No (runtime-compiler build) | Vue Router 4 (`createWebHistory` / `createWebHashHistory`, branched on `isNative()`) | Multi-screen apps with reactive state |
+| React | **Yes, for JSX** | React Router 6 (`createHashRouter`, no branch) | Users who asked for React; otherwise prefer Vue |
+| Alpine.js | No | Pair with platform-conditional History/hash routing | Form-heavy, attribute-driven UIs |
 
 ## Picking rules
 

--- a/docs/API/v3/frameworks/react.md
+++ b/docs/API/v3/frameworks/react.md
@@ -1,5 +1,5 @@
 ---
-description: Constraints for building V3 apps in React. Covers the JSX transpilation problem (the #1 cause of first-deploy failures) with three alternatives, React Router 6 basename wiring to Fliplet.Router.getBasePath, and the no-build-step limits on CSS modules and TSX.
+description: Constraints for building V3 apps in React. Covers the JSX transpilation problem (the #1 cause of first-deploy failures) with three alternatives, React Router 6 createHashRouter wiring (no basename — native- and preview-iframe-safe), and the no-build-step limits on CSS modules and TSX.
 ---
 
 # V3 React apps
@@ -19,7 +19,7 @@ const ReactDOM = window.ReactDOM;
 
 `Fliplet.require.lazy(name)` resolves once the UMD bundle has executed; the module itself lands on `window` (`window.React`, `window.ReactDOM`, `window.htm`, `window.ReactRouterDOM`). Read it off `window` after the `await` — assigning the awaited value directly gives you the URL string, not the module.
 
-For routing, `react-router-dom`'s UMD bundle is not self-contained — it delegates its named exports (`Navigate`, `Outlet`, `useNavigate`, `useLocation`, `Link`, `createBrowserRouter`, …) to two peer packages that must be loaded first as globals:
+For routing, `react-router-dom`'s UMD bundle is not self-contained — it delegates its named exports (`Navigate`, `Outlet`, `useNavigate`, `useLocation`, `Link`, `createHashRouter`, …) to two peer packages that must be loaded first as globals:
 
 ```js
 await Fliplet.require.lazy('@remix-run/router');  // sets window.RemixRouter
@@ -30,7 +30,7 @@ const ReactRouterDOM = window.ReactRouterDOM;
 
 Add all three via `add_dependencies` with `lazy: true` and match the minor versions across them (e.g. `react-router-dom@6.26.x` + `react-router@6.26.x` + `@remix-run/router@1.19.x`). Skipping `react-router` or `@remix-run/router` leaves `ReactRouterDOM.Navigate` etc. as throwing getters that fail at first render.
 
-Adding them via `add_dependencies` is not enough — listing a package as a lazy dep only registers the URL. The boot script must also `await Fliplet.require.lazy(name)` on all three (in the order above) before accessing any `ReactRouterDOM.*` export, or you'll hit `ReactRouterDOM.createBrowserRouter is not a function`.
+Adding them via `add_dependencies` is not enough — listing a package as a lazy dep only registers the URL. The boot script must also `await Fliplet.require.lazy(name)` on all three (in the order above) before accessing any `ReactRouterDOM.*` export, or you'll hit `ReactRouterDOM.createHashRouter is not a function`.
 
 ## Features that need a build step
 
@@ -59,15 +59,13 @@ Prefer `htm` unless the user has a specific reason to override.
 
 ## Wiring to Fliplet.Router
 
-Full contract in [V3 routing](../routing.md). React-specific: pass `basename` when creating the router:
+Full contract in [V3 routing](../routing.md). React-specific: use `createHashRouter` (no basename) on every platform:
 
 ```js
-const router = createBrowserRouter(routes, {
-  basename: Fliplet.Router.getBasePath()
-});
+const router = ReactRouterDOM.createHashRouter(routes);   // no basename
 ```
 
-`HashRouter` is rejected by the boot-HTML lint (rule `hash-router-react`). Build routes from `Fliplet.Router.getRouteManifest()`; route loaders should call `Fliplet.Router.resolveRoute(path)`.
+`createHashRouter` is the V3 standard for React because it sidesteps two problems at once: `createBrowserRouter` renders blank in the V3 preview iframe (the initial URL has no path after the basename), and on native it throws a `file:` `SecurityError` (`file://` blocks `pushState` path changes). Hash mode only ever touches the fragment, so the same router works on web and native with no platform branch — unlike Vue and vanilla, which must branch on `Fliplet.Router.isNative()`. The boot-HTML lint flags both `createBrowserRouter` (`react-browser-router`) and the `<HashRouter>` component (`hash-router-react`); use the `createHashRouter` data-router form. Build routes from `Fliplet.Router.getRouteManifest()`; route loaders should call `Fliplet.Router.resolveRoute(path)`.
 
 ## Binding Fliplet.Media.authenticate
 
@@ -96,10 +94,10 @@ Then `<img src={logoSrc} />`. Calling `Fliplet.Media.authenticate` at module sco
 ## DO / DON'T
 
 - DO use `htm` tagged templates as the default JSX alternative.
-- DO pass `basename: Fliplet.Router.getBasePath()` to `createBrowserRouter`.
+- DO use `ReactRouterDOM.createHashRouter(routes)` (no basename) — it works in the preview iframe and on native unchanged.
 - DO resolve `Fliplet.Media.authenticate` inside `useEffect` and store in state.
 - DON'T ship raw JSX — it will always throw on first deploy.
-- DON'T use `HashRouter` — rejected by lint.
+- DON'T use `createBrowserRouter` or the `<HashRouter>` component — both are rejected by lint; use the `createHashRouter` data-router form.
 - DON'T use `.tsx` or TypeScript — no transpiler available.
 - DON'T use CSS Modules or `import './styles.css'` — no bundler.
 - DON'T render with `innerHTML`, `outerHTML`, `insertAdjacentHTML`, or `element.append(htmlString)` inside screen files. If you wrote `el.innerHTML = ...` in a component, you wrote a templating engine — not React — and you introduced an XSS surface on every future edit.

--- a/docs/API/v3/frameworks/vanilla.md
+++ b/docs/API/v3/frameworks/vanilla.md
@@ -1,5 +1,5 @@
 ---
-description: Constraints for building V3 apps in vanilla JavaScript. The simplest baseline — no framework deps to load, no transpile traps. Covers History API routing under Fliplet.Router.getBasePath and media asset binding timing.
+description: Constraints for building V3 apps in vanilla JavaScript. The simplest baseline — no framework deps to load, no transpile traps. Covers platform-conditional routing (History API + Fliplet.Router.getBasePath on web, location.hash on native, branched on Fliplet.Router.isNative) and media asset binding timing.
 ---
 
 # V3 vanilla-JS apps
@@ -21,14 +21,18 @@ Modern browser syntax (optional chaining, nullish coalescing, destructuring, asy
 
 ## Wiring to Fliplet.Router
 
-Use the History API directly. The navigation call is:
+Navigation is platform-conditional: the History API on web, the hash on native (Cordova `file://` blocks `pushState` path changes). Branch on `Fliplet.Router.isNative()`:
 
 ```js
-history.pushState({}, '', Fliplet.Router.getBasePath() + path);
-window.dispatchEvent(new PopStateEvent('popstate'));
+if (Fliplet.Router.isNative()) {
+  location.hash = path;                                        // native — fires 'hashchange'
+} else {
+  history.pushState({}, '', Fliplet.Router.getBasePath() + path);
+  window.dispatchEvent(new PopStateEvent('popstate'));         // web — fires 'popstate'
+}
 ```
 
-Read the current route by stripping `Fliplet.Router.getBasePath()` from `location.pathname`. Route resolution (access check + screen-source fetch) goes through `Fliplet.Router.resolveRoute(path)` — see [V3 routing](../routing.md).
+Read the current route from `location.hash` on native, or by stripping `Fliplet.Router.getBasePath()` from `location.pathname` on web. Listen for `hashchange` on native and `popstate` on web — match the listener to the navigation mechanism. Route resolution (access check + screen-source fetch) goes through `Fliplet.Router.resolveRoute(path)` — see [V3 routing](../routing.md).
 
 ## Binding Fliplet.Media.authenticate
 
@@ -51,10 +55,11 @@ Don't compute the URL at module load and hope it's ready — the element will ha
 
 ## DO / DON'T
 
-- DO navigate with `history.pushState(state, '', Fliplet.Router.getBasePath() + path)`.
-- DO dispatch `popstate` after `pushState` so listeners re-render.
-- DON'T read or write `window.location.hash` — rejected by the routing lint.
-- DON'T use `href="#/..."` for internal links — rejected by the routing lint.
+- DO branch navigation on `Fliplet.Router.isNative()` — `location.hash = path` on native, `history.pushState(state, '', Fliplet.Router.getBasePath() + path)` on web.
+- DO dispatch `popstate` after `pushState` on web so listeners re-render; on native the `hashchange` event fires on its own.
+- DO listen for `hashchange` on native and `popstate` on web — match the listener to the navigation mechanism.
+- DON'T read or write `window.location.hash` on web — the routing lint flags it unless you branch on `Fliplet.Router.isNative()` (hash is the required native branch).
+- DON'T use `href="#/..."` literals for internal links — render real paths and intercept clicks, letting the platform pick the URL shape.
 - DON'T `import` across uploaded source files — resolve shared code via `Fliplet.require.lazy` or a single boot file.
 
 ## Related

--- a/docs/API/v3/frameworks/vue.md
+++ b/docs/API/v3/frameworks/vue.md
@@ -1,5 +1,5 @@
 ---
-description: Constraints for building V3 apps in Vue 3. Covers the runtime-compiler vs runtime-only build choice, the .vue single-file-component tradeoff without a loader, and the Vue Router base-path wiring to Fliplet.Router.getBasePath.
+description: Constraints for building V3 apps in Vue 3. Covers the runtime-compiler vs runtime-only build choice, the .vue single-file-component tradeoff without a loader, and the platform-conditional Vue Router history wiring (createWebHistory + base path on web, createWebHashHistory on native, branched on Fliplet.Router.isNative).
 ---
 
 # V3 Vue apps
@@ -38,16 +38,18 @@ const VueRouter = window.VueRouter;
 
 ## Wiring to Fliplet.Router
 
-Full contract is in [V3 routing](../routing.md). Vue-specific note: pass the base path into `createWebHistory`:
+Full contract is in [V3 routing](../routing.md). Vue-specific note: the history backend is platform-conditional — path history with the base path on web, hash history on native (Cordova `file://` blocks `pushState` path changes):
 
 ```js
 const router = VueRouter.createRouter({
-  history: VueRouter.createWebHistory(Fliplet.Router.getBasePath()),
+  history: Fliplet.Router.isNative()
+    ? VueRouter.createWebHashHistory()                       // native — hash only
+    : VueRouter.createWebHistory(Fliplet.Router.getBasePath()), // web — path + basename
   routes: [...]
 });
 ```
 
-`createWebHashHistory` is rejected by the boot-HTML lint (rule `create-web-hash-history`).
+Unconditional `createWebHistory()` throws a `file:` `SecurityError` on native; unconditional `createWebHashHistory()` produces ugly `#/route` URLs on web. The boot-HTML lint flags both unless you branch on `Fliplet.Router.isNative()` (`unguarded-web-history` / `create-web-hash-history`).
 
 Build routes from `Fliplet.Router.getRouteManifest()` — do not hardcode. In each route's resolver, call `Fliplet.Router.resolveRoute(path)`. The `content` field in its result IS the screen's source — already fetched for you via `Fliplet.Media.getContents`. Return it from your loader and render it in your component; don't fetch the file again.
 
@@ -77,8 +79,10 @@ Then `<img :src="logoSrc">`. Using `src="{{ rawUrl }}"` directly, or computing t
 
 - DO use `Fliplet.require.lazy('vue')` and the runtime-compiler build.
 - DO build the router from `Fliplet.Router.getRouteManifest()` + `getBasePath()`.
+- DO branch the history backend on `Fliplet.Router.isNative()` — `createWebHashHistory()` on native, `createWebHistory(getBasePath())` on web.
 - DO bind authenticated media URLs into reactive `data()` fields.
-- DON'T use `createWebHashHistory` — rejected by lint.
+- DON'T use `createWebHistory()` unconditionally — it throws a `file:` `SecurityError` on native. Gate it on `Fliplet.Router.isNative()`.
+- DON'T use `createWebHashHistory()` on web — hash mode is only for native.
 - DON'T author `.vue` SFCs without `vue3-sfc-loader` loaded.
 - DON'T `import` anything — use `Fliplet.require.lazy`.
 

--- a/docs/API/v3/routing.md
+++ b/docs/API/v3/routing.md
@@ -19,7 +19,11 @@ Routing in V3 is non-obvious because the defaults in most frameworks are wrong f
 
 ## The contract
 
-V3 uses the **History API on every platform** (web, preview iframe, and native). Hash routing is forbidden because every hosting context (slug-hosted web apps, the Studio preview iframe, and native shells) mounts the SPA at a different base path. Hashes hide that base from the server, break deep-link sharing, and make post-login redirects unreliable across the three contexts.
+V3 routing is **platform-conditional**: the **History API on web** (slug-hosted apps and the Studio preview iframe) and **hash routing on native** (Cordova `file://` shells). `Fliplet.Router` is the single source of truth for the decision — `Fliplet.Router.isNative()` returns whether the app is running in a native shell, and `Fliplet.Router.getHistoryMode()` returns `'hash'` on native, `'history'` on web.
+
+On web, hash routing is wrong: every hosting context mounts the SPA at a different base path, and hashes hide that base from the server, break deep-link sharing, and make post-login redirects unreliable. On native, path-based history is *impossible*: WebKit blocks `history.pushState()` / `replaceState()` from changing the path of a `file:` URL — only the query and fragment may change — so the first path navigation throws `SecurityError: … Only differences in query and fragment are allowed for file: URLs` and the screen goes blank. Native apps must route through the hash.
+
+Build the history backend by branching on `Fliplet.Router.isNative()` — see the per-framework examples below. React is the exception: it uses `createHashRouter` on both platforms (which also fixes a preview-iframe blank-render issue), so it needs no branch.
 
 <p class="info"><code>Fliplet.Router</code> is auto-loaded on V3 apps and is the only sanctioned router API. You build your framework's router from the manifest; you do not hand-roll routes.</p>
 
@@ -30,7 +34,7 @@ var manifest = Fliplet.Router.getRouteManifest();   // { routes, defaultRoute, a
 
 Four requirements:
 
-1. **Read the base path** with `Fliplet.Router.getBasePath()` and pass it to your router's history/basename option. Never hardcode `'/'`. Slug-hosted apps, preview iframes, and native shells all have different bases.
+1. **On web, read the base path** with `Fliplet.Router.getBasePath()` and pass it to your router's history/basename option. Never hardcode `'/'`. Slug-hosted apps and preview iframes host the SPA under different non-root bases. On native the app routes through the hash, so the base path doesn't apply to the history backend (`createWebHashHistory()` / `location.hash` take no base). Branch on `Fliplet.Router.isNative()`.
 2. **Read the manifest** with `Fliplet.Router.getRouteManifest()`. Build your route table from `manifest.routes`. The manifest lives at `app.settings.v3` (see [App settings](app-settings.md)). Update it via the App Settings API (`PUT /v1/apps/:id` with `settings.v3`) or the Studio routing UI whenever you add or remove a user-visible route.
 3. **Guard each route with `Fliplet.Router.resolveRoute(path)`** in the component, loader, or resolver:
    - It returns `{ allowed: true, content, route }` on success.
@@ -45,16 +49,20 @@ Four requirements:
 
 These patterns break V3 apps on at least one hosting context (slug-hosted web, preview iframe, or native). Treat them as hard constraints. The Fliplet Studio AI builder enforces them with an automated lint on generated boot HTML (each violation carries a `ruleId` matching the rows below); hand-authored apps must follow the same rules.
 
-| `ruleId` | What's forbidden | What to do instead |
+The hash rows are **platform-conditional**: hash navigation is *required* on native, so the lint suppresses them when the boot HTML branches on `Fliplet.Router.isNative()` / `getHistoryMode()`. Unguarded, they fire — because hash mode on web (or path mode on native) is wrong. The two React rows fire **unconditionally**: `createHashRouter` is correct for React on every platform, so neither `createBrowserRouter` nor the `<HashRouter>` component is ever right in a V3 app.
+
+| `ruleId` | What's forbidden (unguarded) | What to do instead |
 |---|---|---|
-| `hash-change-event` | `window.addEventListener('hashchange', …)` or `window.onhashchange = …` | Use `popstate` with `history.pushState`. The browser fires `popstate` on back/forward; call `pushState` explicitly when navigating. |
-| `window-location-hash` | Reading or writing `window.location.hash` / `location.hash` | Navigate with `history.pushState(state, '', Fliplet.Router.getBasePath() + path)`. Read the current path from `location.pathname` after stripping the base prefix. |
-| `create-web-hash-history` | `VueRouter.createWebHashHistory(…)` | `VueRouter.createWebHistory(Fliplet.Router.getBasePath())`. |
-| `hash-router-react` | `HashRouter` (React Router) | `createBrowserRouter(routes, { basename: Fliplet.Router.getBasePath() })`. |
-| `hash-href` | `href="#/..."` or `href='#/...'` | Use real paths (`href="/home"`) and intercept clicks to call `history.pushState` via your router. |
+| `hash-change-event` | `window.addEventListener('hashchange', …)` or `window.onhashchange = …` with no platform guard | On web, use `popstate` with `history.pushState`. On native, `hashchange` is the correct event — branch on `Fliplet.Router.isNative()` so the listener matches the navigation mechanism (`popstate` on web, `hashchange` on native). |
+| `window-location-hash` | Reading or writing `window.location.hash` / `location.hash` with no platform guard | On web, navigate with `history.pushState(state, '', Fliplet.Router.getBasePath() + path)` and read the current path from `location.pathname` after stripping the base. On native, `location.hash` is required (path `pushState` is blocked on `file:`). Branch on `Fliplet.Router.isNative()`. |
+| `create-web-hash-history` | `VueRouter.createWebHashHistory(…)` used unconditionally | Make it platform-conditional: `Fliplet.Router.isNative() ? VueRouter.createWebHashHistory() : VueRouter.createWebHistory(Fliplet.Router.getBasePath())`. |
+| `unguarded-web-history` | `VueRouter.createWebHistory(…)` with no platform guard anywhere in the document | Same branch as above — unguarded path history throws a `file:` `SecurityError` on native. Gate the history backend on `Fliplet.Router.isNative()`. |
+| `react-browser-router` | `createBrowserRouter(…)` (React Router) | `ReactRouterDOM.createHashRouter(routes)` (no basename). It renders correctly in the preview iframe and works on native unchanged — React needs no platform branch. |
+| `hash-router-react` | `HashRouter` component (React Router) | Use the `createHashRouter(routes)` data-router form, not the `<HashRouter>` component. |
+| `hash-href` | `href="#/..."` or `href='#/...'` in markup with no platform guard | Render real paths (`href="/home"`) and intercept clicks to call your router, which picks the URL shape per platform (path on web, hash on native). |
 | `path-dispatcher` | 3+ `if (location.pathname === '/…')` branches, or `switch (location.pathname) { case '/…': … }`, used as a hand-rolled router | Build your framework's router from `Fliplet.Router.getRouteManifest()`. Each framework's wiring is in [Framework examples](#framework-examples) below. Single-branch guards like `if (location.pathname === '/login') return;` are fine — the lint only fires on dispatcher-shaped chains. |
 
-These six rules are the ones Fliplet can detect automatically from the boot HTML. Additional anti-patterns (hand-rolled `SCREENS` maps, pathname reads without base-stripping, double-fetching media) live in the [Common pitfalls](#common-pitfalls) section below. They aren't detected statically but are equally wrong.
+These rules are the ones Fliplet can detect automatically from the boot HTML. Additional anti-patterns (hand-rolled `SCREENS` maps, pathname reads without base-stripping, double-fetching media) live in the [Common pitfalls](#common-pitfalls) section below. They aren't detected statically but are equally wrong.
 
 ## Framework examples
 
@@ -79,7 +87,11 @@ Every example assumes this manifest shape (see [App settings](app-settings.md) f
 ```js
 Fliplet.require.lazy('vue-router').then(function() {
   var manifest = Fliplet.Router.getRouteManifest();
-  var history = VueRouter.createWebHistory(Fliplet.Router.getBasePath());
+  // Platform-conditional: native (file://) must route through the hash; web
+  // uses path history under the base path.
+  var history = Fliplet.Router.isNative()
+    ? VueRouter.createWebHashHistory()                         // native — hash only
+    : VueRouter.createWebHistory(Fliplet.Router.getBasePath()); // web — path + basename
 
   var routes = manifest.routes.map(function(r) {
     return {
@@ -140,8 +152,10 @@ Fliplet.require.lazy('vue-router').then(function() {
   routes.unshift({ path: '/', redirect: manifest.defaultRoute });
 
   var router = new VueRouter({
-    mode: 'history',
-    base: Fliplet.Router.getBasePath(),
+    // Platform-conditional: native (file://) must use hash mode; web uses
+    // path history under the base path.
+    mode: Fliplet.Router.isNative() ? 'hash' : 'history',
+    base: Fliplet.Router.isNative() ? undefined : Fliplet.Router.getBasePath(),
     routes: routes
   });
 });
@@ -149,7 +163,7 @@ Fliplet.require.lazy('vue-router').then(function() {
 
 ### React Router 6
 
-React Router doesn't infer the base path; you must pass it to `basename`. Use a loader to call `resolveRoute` before the component renders.
+React uses `createHashRouter` (no basename) on every platform — it sidesteps both the preview-iframe blank-render issue (initial URL has no path after the basename) and the native `file:` `pushState` restriction, so no platform branch is needed. Use a loader to call `resolveRoute` before the component renders.
 
 ```js
 Fliplet.require.lazy('react-router-dom').then(function() {
@@ -177,9 +191,7 @@ Fliplet.require.lazy('react-router-dom').then(function() {
 
   routes.unshift({ path: '/', loader: function() { throw ReactRouterDOM.redirect(manifest.defaultRoute); } });
 
-  var router = ReactRouterDOM.createBrowserRouter(routes, {
-    basename: Fliplet.Router.getBasePath()
-  });
+  var router = ReactRouterDOM.createHashRouter(routes);   // no basename — hash mode works in the preview iframe and on native unchanged
 });
 ```
 
@@ -192,17 +204,28 @@ Most Svelte routers default to hash mode. Pick one that supports history, or thi
 ```js
 var manifest = Fliplet.Router.getRouteManifest();
 var base = Fliplet.Router.getBasePath();
+var native = Fliplet.Router.isNative();   // file:// → route via the hash
+var basePrefix = base.replace(/\/$/, '');
+
+function currentPath() {
+  if (native) return location.hash.replace(/^#/, '') || '/';
+  return location.pathname.replace(new RegExp('^' + basePrefix), '') || '/';
+}
 
 function navigate(path) {
-  history.pushState({}, '', base.replace(/\/$/, '') + path);
-  render(path);
+  if (native) {
+    location.hash = path;                 // fires 'hashchange' → render
+  } else {
+    history.pushState({}, '', basePrefix + path);
+    render(path);                         // pushState doesn't fire popstate; render directly
+  }
 }
 
 function render(path) {
   var target = path === '/' ? manifest.defaultRoute : path;
 
   Fliplet.Router.resolveRoute(target).then(function(result) {
-    if (location.pathname !== base.replace(/\/$/, '') + target) return; // stale
+    if (currentPath() !== target) return; // stale
 
     if (!result.allowed) {
       navigate(result.redirectTo);
@@ -214,22 +237,29 @@ function render(path) {
   });
 }
 
-window.addEventListener('popstate', function() {
-  render(location.pathname.replace(new RegExp('^' + base.replace(/\/$/, '')), '') || '/');
+// hashchange on native, popstate on web — matches the navigate() mechanism.
+window.addEventListener(native ? 'hashchange' : 'popstate', function() {
+  render(currentPath());
 });
 
-render(location.pathname.replace(new RegExp('^' + base.replace(/\/$/, '')), '') || '/');
+render(currentPath());
 ```
 
 ### Vanilla JS (no router library)
 
-Same pattern as Svelte: `pushState` for navigation, `popstate` for back/forward, normalize against the base path. Keep a module-scoped `currentNavId` to ignore stale resolutions:
+Same pattern as Svelte, branched on platform: on web `pushState` for navigation and `popstate` for back/forward (normalized against the base path); on native `location.hash` and `hashchange` (path `pushState` is blocked on `file:`). Keep a module-scoped `currentNavId` to ignore stale resolutions:
 
 ```js
 var manifest = Fliplet.Router.getRouteManifest();
 var base = Fliplet.Router.getBasePath();
 var basePrefix = base.replace(/\/$/, '');
+var native = Fliplet.Router.isNative();   // file:// → route via the hash
 var currentNavId = 0;
+
+function currentPath() {
+  if (native) return location.hash.replace(/^#/, '') || '/';
+  return stripBase(location.pathname);
+}
 
 function stripBase(pathname) {
   if (basePrefix && pathname.indexOf(basePrefix) === 0) {
@@ -255,8 +285,12 @@ function render(path) {
 }
 
 function navigate(path) {
-  history.pushState({}, '', basePrefix + path);
-  render(path);
+  if (native) {
+    location.hash = path;                 // fires 'hashchange' → render
+  } else {
+    history.pushState({}, '', basePrefix + path);
+    render(path);                         // pushState doesn't fire popstate; render directly
+  }
 }
 
 document.addEventListener('click', function(event) {
@@ -266,11 +300,12 @@ document.addEventListener('click', function(event) {
   navigate(link.getAttribute('href'));
 });
 
-window.addEventListener('popstate', function() {
-  render(stripBase(location.pathname));
+// hashchange on native, popstate on web — matches the navigate() mechanism.
+window.addEventListener(native ? 'hashchange' : 'popstate', function() {
+  render(currentPath());
 });
 
-render(stripBase(location.pathname));
+render(currentPath());
 ```
 
 ## Post-login redirect
@@ -308,7 +343,7 @@ Replace `navigate(...)` with the same helper used in your router (Svelte, vanill
 ## Common pitfalls
 
 - **Don't hand-roll a `SCREENS = { home: 1234, … }` map or a pathname-if-chain.** That's what the route manifest is for. Store it in `app.settings.v3` and read it back via `Fliplet.Router.getRouteManifest().routes`. Hand-rolled maps drift when screens are renamed, duplicate the `public` and `fileId` metadata the server already authored, and bypass the manifest as the single source of truth for routing.
-- **Don't read `window.location.pathname` directly to determine the current route.** Strip the base path first. `Fliplet.Router.getBasePath()` returns the prefix to remove. Slug-hosted apps and preview iframes host the SPA under a non-root path; raw `pathname` reads will misidentify the current route in both contexts.
+- **Don't read `window.location.pathname` directly to determine the current route.** On web, strip the base path first — `Fliplet.Router.getBasePath()` returns the prefix to remove. Slug-hosted apps and preview iframes host the SPA under a non-root path; raw `pathname` reads will misidentify the current route in both contexts. On native the route lives in `location.hash`, not the pathname — branch on `Fliplet.Router.isNative()` (a single `currentPath()` helper that returns the hash on native and the base-stripped pathname on web keeps the rest of the router platform-agnostic).
 - **Don't fetch the screen's media URL yourself.** `Fliplet.Router.resolveRoute` already calls `Fliplet.Media.getContents(fileId)` under the hood and returns the content in `result.content`. A second fetch duplicates the network round trip, can race with the access check, and will fail outright on private media where auth headers aren't applied.
 - **Don't discard `result.content` from `resolveRoute`.** The `content` field IS the screen's source — already fetched for you. Your route loader should return `{ content: result.content, route: result.route }` so the component can render `data.content` directly. If your loader returns only `{ path }` and your screens are defined inline in the component, you've duplicated every screen in two places — the manifest's `fileId` and the hardcoded inline copy — and you've paid for a fetch you then threw away. The `resolveRoute` name is the hint: the method resolves a route to its **full resolution** (access + content), not just an access decision.
 - **Don't assume the server-side ACL matches the manifest's `public` flag.** The manifest is advisory; the server decides. Always handle `reason: 'media-denied'`. Flipping `public: true` without updating the media file's access rule grants no access; you'll ship an app that works in dev and 401s in production.


### PR DESCRIPTION
## Problem

The V3 AI builder fetches `docs/API/v3/*.md` as its **canonical** routing reference (via `fetch_fliplet_doc`), and the model treats them as authoritative — outweighing the studio-side skill guidance. Every routing doc mandated unconditional path-based History API and declared hash mode forbidden, e.g. `routing.md` opened with *"History API on every platform (web, preview iframe, and native). Hash routing is forbidden."*

That's wrong on native: Cordova serves pages from `file://`, where WebKit blocks `pushState` path changes, so `createWebHistory` throws a `SecurityError` and the screen goes blank. The contradicting docs are why AI builds emitted ungated `createWebHistory(getBasePath())` on the first pass (only the lint backstop caught it).

## What this PR does (Layer 3 — docs)

Brings the canonical docs in line with the studio skills + `lintV3Boot`:

- **`routing.md`** (canonical) — rewrote the contract (path on web, hash on native, `Fliplet.Router.isNative()` / `getHistoryMode()` as the single source of truth + the `file:` `SecurityError` rationale); requirement #1; the forbidden-patterns table (hash rows now platform-conditional / suppressed when guarded; added `unguarded-web-history` and `react-browser-router` rows matching the lint `ruleId`s); and all five framework examples (Vue 4, Vue 3, **React → `createHashRouter`**, Svelte, vanilla).
- **`frameworks/vue.md` / `vanilla.md` / `alpine.md`** — wiring + DO/DON'T branch on `isNative()`.
- **`frameworks/react.md`** — `createBrowserRouter`+basename → `createHashRouter` (no basename); the studio lint now rejects `createBrowserRouter`.
- **`frameworks/overview.md`** — constraints + comparison tables.
- **`fliplet-router.md`** — fixed example + documented the new `isNative()` / `getHistoryMode()` methods.
- **`app-bootstrap.md` / `auth.md`** — routing pointer + logout-redirect guidance.
- Frontmatter descriptions updated so native/hash routing surfaces in `search_fliplet_docs`.

All new code examples are lint-clean (every hash example carries an `isNative()` guard; React uses `createHashRouter`; no ungated `createWebHistory`).

## Companion PRs (same branch name, all → `development`)

- **fliplet-api** `fix/DEV-1306` (#8122) — `router.js` `isNative`/`getHistoryMode` + hash-aware analytics.
- **fliplet-studio** `fix/DEV-1306` (#8576) — AI builder skills + boot-HTML lint.

Note: these docs reach the builder once merged + the docs site rebuilds, or via `STUDIO_BRANCH=fix/DEV-1306` (GitHub-raw fetch) for pre-merge eval runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)