### PR TITLE
DEV-1264: Document camera/photo capture in Fliplet.Media dev docs

### DIFF
--- a/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
+++ b/docs/.well-known/agent-skills/fliplet-js-api/SKILL.md
@@ -61,7 +61,7 @@ The Fliplet client-side JavaScript API: every Fliplet.X namespace (Storage, User
 - [Fliplet.Database](https://developers.fliplet.com/API/fliplet-database.html): Low-level helper for reading and querying JSON data from a local file as a database; used internally by Fliplet.DataSources.
 - [Fliplet.DataSources.Encryption](https://developers.fliplet.com/API/fliplet-encryption.html): Automatically encrypt and decrypt selected Data Source columns on-device by registering a private key and column list.
 - [Fliplet.Gamify](https://developers.fliplet.com/API/fliplet-gamify.html): Configure gamification with logs, variables, and achievements via Fliplet.Gamify; track points, milestones, and badges backed by a data source per user.
-- [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.
+- [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, capture photos and video from the device camera, and download media via the Fliplet Media namespace.
 - [Fliplet.Notifications](https://developers.fliplet.com/API/fliplet-notifications.html): Read, send, and schedule in-app and push notifications in Fliplet apps, with support for scopes, read receipts, and badge counts.
 - [Fliplet.Page](https://developers.fliplet.com/API/fliplet-page.html): Utilities for interacting with the current Fliplet screen — including smooth-scrolling to an element with configurable duration and offsets.
 - [Fliplet.Payments](https://developers.fliplet.com/API/fliplet-payments.html): Accept Stripe payments and checkout in Fliplet apps via Fliplet.Payments, with a products data source and webhook-driven order tracking.

--- a/docs/.well-known/agent-skills/index.json
+++ b/docs/.well-known/agent-skills/index.json
@@ -130,7 +130,7 @@
       "tags": [
         "js-api"
       ],
-      "sha256": "1e5a933f3b7a286d7a1cc84417319e10eece8e986cecb8389c943e3b45a83658"
+      "sha256": "5de68ae6901a14c2759971079914a4ee7cdd747661f5492222bed29dbf618836"
     },
     {
       "name": "fliplet-docs-index",

--- a/docs/.well-known/llms-full.txt
+++ b/docs/.well-known/llms-full.txt
@@ -15443,6 +15443,64 @@ Please note that the following image content types are automatically resized to 
 - `image/svg+xml`: Scalable Vector Graphics (SVG)
 - `image/webp`: Web Picture format (WEBP)
 
+### Capture a photo or video from the camera
+
+`Fliplet.Media` **stores** files — it does not capture them. To let users take a photo or record a video, capture the file first, then upload it with `Fliplet.Media.Files.upload`.
+
+**Platform support:** the recommended approach below works on **both web and native** (iOS/Android) from the same code — do **not** gate it behind `Fliplet.Router.isNative()`.
+
+| Platform | How the file input behaves |
+|---|---|
+| Web (browser) | Opens the OS file picker; mobile browsers offer the camera directly |
+| Native (iOS/Android) | The same input opens the native camera / photo-library picker |
+
+```html
+<input type="file" id="photo" accept="image/*" capture="environment">
+```
+
+```js
+document.querySelector('#photo').addEventListener('change', function (event) {
+  var file = event.target.files[0];
+  if (!file) {
+    return;
+  }
+
+  var formData = new FormData();
+  formData.append('files', file);
+
+  Fliplet.Media.Files.upload({
+    data: formData,
+    folderId: 1 // optional
+  }).then(function (files) {
+    // files[0].url → the stored image/video URL
+  });
+});
+```
+
+<p class="quote"><strong>Permissions:</strong> On <strong>web</strong>, the browser prompts for camera access when the capture UI opens and requires a secure context (HTTPS) — no extra code is needed. On <strong>native</strong>, the OS prompts on first use; custom app wrappers must declare a camera usage description (iOS <code>NSCameraUsageDescription</code>).</p>
+
+**Capturing video or any file type:** change `accept` (e.g. `accept="video/*"`, `capture="user"` for the front camera, or omit `capture` to allow gallery selection). For live in-browser capture you can also use the standard `navigator.mediaDevices.getUserMedia` + `MediaRecorder` APIs, then upload the resulting blob the same way.
+
+**Native enhanced camera UI (optional).** Inside the native app only, the Cordova camera plugin exposes a richer camera/photo-library popover. It is **undefined on web**, so always guard it and fall back to the file input:
+
+```js
+if (!Fliplet.Env.is('web') && navigator.camera) {
+  navigator.camera.getPicture(onSuccess, onError, {
+    sourceType: Camera.PictureSourceType.CAMERA, // or PHOTOLIBRARY
+    destinationType: Camera.DestinationType.FILE_URI,
+    encodingType: Camera.EncodingType.JPEG,
+    mediaType: Camera.MediaType.PICTURE,
+    correctOrientation: true
+  });
+  // A FILE_URI result is a file:/content: URI — resolve it to a File before upload:
+  // window.resolveLocalFileSystemURL(uri, entry => entry.file(file => /* upload file */));
+} else {
+  document.querySelector('#photo').click(); // web / fallback: use the file input above
+}
+```
+
+<p class="quote"><strong>Note:</strong> Do <strong>not</strong> call <code>navigator.camera.getPicture()</code> without the web guard — it is native-only and throws on web. The native camera encodes images as JPEG; uploaded images are auto-resized (see the list above), and you may normalize to WebP via a canvas if you want smaller, consistent files.</p>
+
 ### Delete a file
 
 ```js

--- a/docs/.well-known/llms-v3-libraries.json
+++ b/docs/.well-known/llms-v3-libraries.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-16T15:54:05.264Z",
+  "generatedAt": "2026-06-10T21:06:10.561Z",
   "libraries": [
     {
       "package": "fliplet-app-submissions",
@@ -158,7 +158,7 @@
       "package": "fliplet-media",
       "namespace": "Fliplet.Media",
       "title": "Fliplet.Media",
-      "description": "Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.",
+      "description": "Browse folders, upload and manage files, capture photos and video from the device camera, and download media via the Fliplet Media namespace.",
       "docUrl": "https://developers.fliplet.com/API/fliplet-media.html",
       "preloaded": false,
       "capabilities": [
@@ -170,6 +170,13 @@
         "image",
         "picture",
         "photo",
+        "camera",
+        "take photo",
+        "photo capture",
+        "capture image",
+        "scan document",
+        "video capture",
+        "record video",
         "file storage",
         "file manager",
         "attachment",

--- a/docs/.well-known/llms.txt
+++ b/docs/.well-known/llms.txt
@@ -110,7 +110,7 @@
 - [Fliplet.DataSources](https://developers.fliplet.com/API/fliplet-datasources.html): Connect to, query, insert, update, and delete records in Fliplet Data Sources from inside an app. All methods are promise-based.
 - [Fliplet.DataSources.Encryption](https://developers.fliplet.com/API/fliplet-encryption.html): Automatically encrypt and decrypt selected Data Source columns on-device by registering a private key and column list.
 - [Fliplet.Gamify](https://developers.fliplet.com/API/fliplet-gamify.html): Configure gamification with logs, variables, and achievements via Fliplet.Gamify; track points, milestones, and badges backed by a data source per user.
-- [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace.
+- [Fliplet.Media](https://developers.fliplet.com/API/fliplet-media.html): Browse folders, upload and manage files, capture photos and video from the device camera, and download media via the Fliplet Media namespace.
 - [Fliplet.Notifications](https://developers.fliplet.com/API/fliplet-notifications.html): Read, send, and schedule in-app and push notifications in Fliplet apps, with support for scopes, read receipts, and badge counts.
 - [Fliplet.OAuth2 (Beta)](https://developers.fliplet.com/API/fliplet-oauth2.html): The `fliplet-oauth2` package contains helpers for standardizing requests to OAuth2 web services with a client-side integration.
 - [Fliplet.Page](https://developers.fliplet.com/API/fliplet-page.html): Utilities for interacting with the current Fliplet screen — including smooth-scrolling to an element with configurable duration and offsets.

--- a/docs/API/fliplet-media.md
+++ b/docs/API/fliplet-media.md
@@ -1,11 +1,11 @@
 ---
 title: Fliplet.Media
-description: "Browse folders, upload and manage files, and download media to devices via the Fliplet Media namespace."
+description: "Browse folders, upload and manage files, capture photos and video from the device camera, and download media via the Fliplet Media namespace."
 type: api-reference
 tags: [js-api, media]
 v3_relevant: true
 deprecated: false
-capabilities: [file, folder, upload, download, media, image, picture, photo, file storage, file manager, attachment, browse files, search files]
+capabilities: [file, folder, upload, download, media, image, picture, photo, camera, take photo, photo capture, capture image, scan document, video capture, record video, file storage, file manager, attachment, browse files, search files]
 ---
 # `Fliplet.Media`
 
@@ -140,6 +140,64 @@ Please note that the following image content types are automatically resized to 
 - `image/png`: Portable Network Graphics (PNG)
 - `image/svg+xml`: Scalable Vector Graphics (SVG)
 - `image/webp`: Web Picture format (WEBP)
+
+### Capture a photo or video from the camera
+
+`Fliplet.Media` **stores** files — it does not capture them. To let users take a photo or record a video, capture the file first, then upload it with `Fliplet.Media.Files.upload`.
+
+**Platform support:** the recommended approach below works on **both web and native** (iOS/Android) from the same code — do **not** gate it behind `Fliplet.Router.isNative()`.
+
+| Platform | How the file input behaves |
+|---|---|
+| Web (browser) | Opens the OS file picker; mobile browsers offer the camera directly |
+| Native (iOS/Android) | The same input opens the native camera / photo-library picker |
+
+```html
+<input type="file" id="photo" accept="image/*" capture="environment">
+```
+
+```js
+document.querySelector('#photo').addEventListener('change', function (event) {
+  var file = event.target.files[0];
+  if (!file) {
+    return;
+  }
+
+  var formData = new FormData();
+  formData.append('files', file);
+
+  Fliplet.Media.Files.upload({
+    data: formData,
+    folderId: 1 // optional
+  }).then(function (files) {
+    // files[0].url → the stored image/video URL
+  });
+});
+```
+
+<p class="quote"><strong>Permissions:</strong> On <strong>web</strong>, the browser prompts for camera access when the capture UI opens and requires a secure context (HTTPS) — no extra code is needed. On <strong>native</strong>, the OS prompts on first use; custom app wrappers must declare a camera usage description (iOS <code>NSCameraUsageDescription</code>).</p>
+
+**Capturing video or any file type:** change `accept` (e.g. `accept="video/*"`, `capture="user"` for the front camera, or omit `capture` to allow gallery selection). For live in-browser capture you can also use the standard `navigator.mediaDevices.getUserMedia` + `MediaRecorder` APIs, then upload the resulting blob the same way.
+
+**Native enhanced camera UI (optional).** Inside the native app only, the Cordova camera plugin exposes a richer camera/photo-library popover. It is **undefined on web**, so always guard it and fall back to the file input:
+
+```js
+if (!Fliplet.Env.is('web') && navigator.camera) {
+  navigator.camera.getPicture(onSuccess, onError, {
+    sourceType: Camera.PictureSourceType.CAMERA, // or PHOTOLIBRARY
+    destinationType: Camera.DestinationType.FILE_URI,
+    encodingType: Camera.EncodingType.JPEG,
+    mediaType: Camera.MediaType.PICTURE,
+    correctOrientation: true
+  });
+  // A FILE_URI result is a file:/content: URI — resolve it to a File before upload:
+  // window.resolveLocalFileSystemURL(uri, entry => entry.file(file => /* upload file */));
+} else {
+  document.querySelector('#photo').click(); // web / fallback: use the file input above
+}
+```
+
+<p class="quote"><strong>Note:</strong> Do <strong>not</strong> call <code>navigator.camera.getPicture()</code> without the web guard — it is native-only and throws on web. The native camera encodes images as JPEG; uploaded images are auto-resized (see the list above), and you may normalize to WebP via a canvas if you want smaller, consistent files.</p>
 
 ### Delete a file
 


### PR DESCRIPTION
## JIRA
https://weboo.atlassian.net/browse/DEV-1264 — *Studio V3 — Barcode/capability dev docs unclear to AI; should cover web & native scenarios.*

## Summary
The V3 AI builder mis-handles device capabilities because the dev docs don't state web-vs-native behaviour. For camera/photo capture the AI reaches for native-only `navigator.camera.getPicture()` (undefined on web) and assumes `Fliplet.Media` captures (it only stores). This documents the correct cross-platform path so the AI generates code that works on both web and native.

- Add a **"Capture a photo or video from the camera"** section to `API/fliplet-media.md`:
  - cross-platform path: HTML file input (`<input type="file" accept="image/*" capture>`) → `Fliplet.Media.Files.upload`
  - permissions (web camera prompt + HTTPS; native OS prompt)
  - optional native camera plugin, **guarded** with `Fliplet.Env.is('web')` / `navigator.camera` (+ `resolveLocalFileSystemURL` for `FILE_URI`)
  - formats (native captures JPEG; uploads auto-resize)
- Extend front-matter `description` + `capabilities` (`camera`, `take photo`, `photo capture`, `capture image`, `scan document`, `video capture`, `record video`) so the V3 library registry (`llms-v3-libraries.json`) and `search_fliplet_docs` route camera/photo prompts to `Fliplet.Media`.
- Regenerate `.well-known/` agent indexes via `bin/build-agent-indexes.mjs`.

Paired with the Studio registry-snapshot PR in `Fliplet/fliplet-studio` (same branch name).

## Test plan
- [ ] Run Studio with `STUDIO_BRANCH=feat/DEV-1264`; prompt "let users take a photo" → AI fetches the Media doc and emits `<input capture>` + `Fliplet.Media.Files.upload` (no `navigator.camera.getPicture()` on web, no `isNative()` gate).
- [ ] Verify the rendered docs page on the branch preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)