### PR TITLE
fix(auth): migrate CLI login to /v1/auth/login?return=callback (DEV-1427)

### DIFF
--- a/fliplet-login.js
+++ b/fliplet-login.js
@@ -20,7 +20,7 @@ ${'Press Ctrl+C to exit.'.blue}
 
 const port = 9001;
 const baseUrl = `http://localhost:${port}`;
-const redirectUrl = `${config.api_url}v1/auth/third-party?redirect=${encodeURIComponent(`${baseUrl}/callback`)}&responseType=code&source=CLI&title=Sign%20in%20to%20Authorize%20the%20Fliplet%20CLI`;
+const redirectUrl = `${config.api_url}v1/auth/login?return=callback&callback=${encodeURIComponent(`${baseUrl}/callback`)}&source=CLI`;
 
 require('http').createServer(function(req, res) {
   if (req.url.match(/login/)) {
@@ -38,7 +38,8 @@ require('http').createServer(function(req, res) {
   }
 
   if (req.url.match(/callback/)) {
-    const authToken = _.last(req.url.split('auth_token='));
+    const urlParams = new URLSearchParams(req.url.split('?')[1] || '');
+    const authToken = urlParams.get('token');
 
     auth.setUserForToken(authToken).then(function(user) {
       organizations.getOrganizationsList().then(function onGetOrganizations(organizations) {


### PR DESCRIPTION
## What

Updates the Fliplet CLI login flow to use the new unified Fliplet login endpoint.

**Two changes in \`fliplet-login.js\`:**

1. **Auth URL** — replaces the removed \`/v1/auth/third-party\` endpoint with \`/v1/auth/login?return=callback&callback=<uri>\`:
   \`\`\`diff
   - const redirectUrl = \`\${config.api_url}v1/auth/third-party?redirect=\${encodeURIComponent(\`\${baseUrl}/callback\`)}&responseType=code&source=CLI&title=...\`;
   + const redirectUrl = \`\${config.api_url}v1/auth/login?return=callback&callback=\${encodeURIComponent(\`\${baseUrl}/callback\`)}&source=CLI\`;
   \`\`\`

2. **Token extraction** — reads \`token\` instead of \`auth_token\` from the callback query string, matching what the new login page delivers:
   \`\`\`diff
   - const authToken = _.last(req.url.split('auth_token='));
   + const urlParams = new URLSearchParams(req.url.split('?')[1] || '');
   + const authToken = urlParams.get('token');
   \`\`\`

## Why

DEV-1090 removed the \`/v1/auth/third-party\` endpoint from \`fliplet-api\` (commit \`1d6054e\`, May 2026) as part of the unified login widget redesign. The replacement is \`/v1/auth/login\` in \`return=callback\` mode — on successful sign-in it redirects to the consumer's callback URL with \`?token=<auth_token>&user=<json>\` appended.

The CLI's loopback callback \`http://localhost:9001/callback\` is already in the API's \`redirectAllowlist.js\` — no backend changes needed.

## Related

- Same fix applied to the VS Code/Cursor extension: Fliplet/fliplet-vscode-extension#8
- API change that broke this: \`Fliplet/fliplet-api@1d6054e\` (DEV-1090)