### PR TITLE
DEV-1545: fix Fliplet.Media.capture() return type doc (File web / Blob native)

### DIFF
--- a/docs/.well-known/llms-full.txt
+++ b/docs/.well-known/llms-full.txt
@@ -36120,8 +36120,8 @@ Release notes for the Fliplet iOS and Android native frameworks — rebuild your
   <div class="bl two">
     <div>
       <h4>Android</h4>
-      <p>Current release: <u>6.4.7</u></p>
-      <p>Target API level: 37</p>
+      <p>Current release: <u>6.4.4</u></p>
+      <p>Target API level: 36</p>
       <p>Minimum supported SDK: 29 (Android 10)</p>
     </div>
   </div>
@@ -36131,10 +36131,6 @@ Release notes for the Fliplet iOS and Android native frameworks — rebuild your
 ---
 
 ## Supported versions
-
-### Version 6.4.7 (July 16, 2026)
-
-- **Android**: The target SDK has now been set to 37 (Android 17)
 
 ### Version 6.4.6 (February 09, 2026)
 

--- a/docs/.well-known/llms-full.txt
+++ b/docs/.well-known/llms-full.txt
@@ -28672,7 +28672,7 @@ await Fliplet.require.lazy.chain('fliplet-media');
 
 ## Capturing a photo: Fliplet.Media.capture()
 
-`Fliplet.Media.capture()` resolves with the chosen image as an **optimized WebP `File`** — downscaled to `maxWidth`/`maxHeight` and re-encoded to keep uploads small, so you don't ship a multi-megapixel original over the wire. It works the same on web and native — on native it drives the device camera or photo library; on web it opens the file picker (hinting the camera when you ask for one). You never touch the platform camera APIs yourself, the same way you build a login screen on top of `Fliplet.Session`.
+`Fliplet.Media.capture()` resolves with the chosen image as an **optimized WebP file** — downscaled to `maxWidth`/`maxHeight` and re-encoded to keep uploads small, so you don't ship a multi-megapixel original over the wire. On web this is a real `File`; on native it's a `Blob` with `.name`/`.type` set instead (the platform's file bridge doesn't support constructing a real `File` there) — either way it works directly with `Files.upload()` (below) and `URL.createObjectURL()`. It works the same on web and native — on native it drives the device camera or photo library; on web it opens the file picker (hinting the camera when you ask for one). You never touch the platform camera APIs yourself, the same way you build a login screen on top of `Fliplet.Session`.
 
 ```js
 await Fliplet.require.lazy.chain('fliplet-media');
@@ -28698,7 +28698,7 @@ const picked = await Fliplet.Media.capture({ source: 'library' }); // straight t
 * **options.maxWidth** (Number) — longest-edge width cap in px; the image is scaled down to fit and never upscaled. **Default** `2048`.
 * **options.maxHeight** (Number) — longest-edge height cap in px. **Default** `2048`.
 
-It resolves with an optimized WebP `File` and rejects if the user cancels or no camera is available — handle the rejection so the screen doesn't hang.
+It resolves with an optimized WebP file (a `File` on web, a `Blob` on native) and rejects if the user cancels or no camera is available — handle the rejection so the screen doesn't hang.
 
 > **Photos only.** `capture()` takes still images. To collect audio or video, let the user **upload an existing file** with `Files.upload()` (below) — there is no audio/video *recording* API.
 

--- a/docs/.well-known/llms-full.txt
+++ b/docs/.well-known/llms-full.txt
@@ -36120,8 +36120,8 @@ Release notes for the Fliplet iOS and Android native frameworks — rebuild your
   <div class="bl two">
     <div>
       <h4>Android</h4>
-      <p>Current release: <u>6.4.4</u></p>
-      <p>Target API level: 36</p>
+      <p>Current release: <u>6.4.7</u></p>
+      <p>Target API level: 37</p>
       <p>Minimum supported SDK: 29 (Android 10)</p>
     </div>
   </div>
@@ -36131,6 +36131,10 @@ Release notes for the Fliplet iOS and Android native frameworks — rebuild your
 ---
 
 ## Supported versions
+
+### Version 6.4.7 (July 16, 2026)
+
+- **Android**: The target SDK has now been set to 37 (Android 17)
 
 ### Version 6.4.6 (February 09, 2026)
 

--- a/docs/.well-known/llms-v3-libraries.json
+++ b/docs/.well-known/llms-v3-libraries.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-02T10:13:20.806Z",
+  "generatedAt": "2026-07-16T14:09:23.934Z",
   "libraries": [
     {
       "package": "fliplet-analytics-spa",

--- a/docs/.well-known/llms-v3-libraries.json
+++ b/docs/.well-known/llms-v3-libraries.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-16T14:09:23.934Z",
+  "generatedAt": "2026-07-02T10:13:20.806Z",
   "libraries": [
     {
       "package": "fliplet-analytics-spa",

--- a/docs/API/v3/media.md
+++ b/docs/API/v3/media.md
@@ -27,7 +27,7 @@ await Fliplet.require.lazy.chain('fliplet-media');
 
 ## Capturing a photo: Fliplet.Media.capture()
 
-`Fliplet.Media.capture()` resolves with the chosen image as an **optimized WebP `File`** — downscaled to `maxWidth`/`maxHeight` and re-encoded to keep uploads small, so you don't ship a multi-megapixel original over the wire. It works the same on web and native — on native it drives the device camera or photo library; on web it opens the file picker (hinting the camera when you ask for one). You never touch the platform camera APIs yourself, the same way you build a login screen on top of `Fliplet.Session`.
+`Fliplet.Media.capture()` resolves with the chosen image as an **optimized WebP file** — downscaled to `maxWidth`/`maxHeight` and re-encoded to keep uploads small, so you don't ship a multi-megapixel original over the wire. On web this is a real `File`; on native it's a `Blob` with `.name`/`.type` set instead (the platform's file bridge doesn't support constructing a real `File` there) — either way it works directly with `Files.upload()` (below) and `URL.createObjectURL()`. It works the same on web and native — on native it drives the device camera or photo library; on web it opens the file picker (hinting the camera when you ask for one). You never touch the platform camera APIs yourself, the same way you build a login screen on top of `Fliplet.Session`.
 
 ```js
 await Fliplet.require.lazy.chain('fliplet-media');
@@ -53,7 +53,7 @@ const picked = await Fliplet.Media.capture({ source: 'library' }); // straight t
 * **options.maxWidth** (Number) — longest-edge width cap in px; the image is scaled down to fit and never upscaled. **Default** `2048`.
 * **options.maxHeight** (Number) — longest-edge height cap in px. **Default** `2048`.
 
-It resolves with an optimized WebP `File` and rejects if the user cancels or no camera is available — handle the rejection so the screen doesn't hang.
+It resolves with an optimized WebP file (a `File` on web, a `Blob` on native) and rejects if the user cancels or no camera is available — handle the rejection so the screen doesn't hang.
 
 > **Photos only.** `capture()` takes still images. To collect audio or video, let the user **upload an existing file** with `Files.upload()` (below) — there is no audio/video *recording* API.
 


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/DEV-1545

## Summary
Corrects the published `Fliplet.Media.capture()` doc, which promised the resolved value is always a `File`. On native, `cordova-plugin-file` overrides `window.File`, so the implementation (see [fliplet-api PR #8369](https://github.com/Fliplet/fliplet-api/pull/8369)) resolves with a `Blob` tagged with `.name`/`.type`/`.lastModified` instead of a real `File` there — a genuine native `File` can't be constructed. Web is unaffected; it already resolves with a real `File`.

Raised by the automated reviewer (Arpanexe) on fliplet-api PR #8369 as a doc/implementation contract mismatch.

### Changes
- `docs/API/v3/media.md` — capture() return type documented as `File` (web) / `Blob` (native); both work directly with `Files.upload()` and `URL.createObjectURL()`.
- `docs/.well-known/llms-full.txt` — mirrored the same wording (compiled doc bundle).

Scoped to just these two files — an earlier commit also regenerated the full doc build (which incidentally pulled in an unrelated pre-existing Android changelog sync + a catalog timestamp bump); reverted that so this PR only carries the capture() wording fix.

### Verification
`cd docs && npm run test:unit` (163/163 pass) and `npm run check:docs --strict` (203 docs, 46 V3 libraries, no catalog uniqueness violations) both green against this change.

### Risk Assessment
- Risk Level: LOW — documentation wording only, no code change
- Files Modified: 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)